### PR TITLE
fix: editor choice prompt (TD-1) and force token refresh on 401

### DIFF
--- a/pkg/cli/auth/credentials.go
+++ b/pkg/cli/auth/credentials.go
@@ -18,10 +18,14 @@ type Credentials struct {
 	UserID       string `json:"user_id"`
 }
 
-// IsExpired checks if the access token has expired
+// refreshBuffer is how far before actual expiry we consider a token expired,
+// so we proactively refresh instead of racing the clock.
+const refreshBuffer = 30 * time.Second
+
+// IsExpired checks if the access token has expired (or is within the refresh buffer).
 func (c *Credentials) IsExpired() bool {
 	expiresAt := time.Unix(c.CreatedAt, 0).Add(time.Duration(c.ExpiresIn) * time.Second)
-	return time.Now().After(expiresAt)
+	return time.Now().After(expiresAt.Add(-refreshBuffer))
 }
 
 // ExpiresAt returns the expiration time

--- a/pkg/cli/revise/client.go
+++ b/pkg/cli/revise/client.go
@@ -73,7 +73,9 @@ func (c *ReviseClient) doWithRetry(fn func(token string) (*http.Response, error)
 	if resp.StatusCode == http.StatusUnauthorized {
 		resp.Body.Close()
 
-		newToken, err := auth.GetValidAccessToken()
+		// Force refresh — the server already rejected the current token,
+		// so we must not rely on the local expiry check.
+		newToken, err := auth.ForceRefreshAccessToken()
 		if err != nil {
 			return nil, fmt.Errorf("token refresh failed: %w (run 'sl auth login')", err)
 		}


### PR DESCRIPTION
## Summary
- **TD-1 (specledger/136-revise-comments/plan.md)**: Replace the auto-opening editor in the revise flow with a `huh.Select` prompt giving users the choice to review/edit the prompt in their editor or proceed with the generated prompt as-is. The previous transition message was invisible because the editor immediately took over the terminal.
- **Token refresh fix**: Add 30s buffer to `IsExpired()` for proactive refresh before actual expiry, and introduce `ForceRefreshAccessToken()` used by `doWithRetry()` on 401 so it doesn't return the same server-rejected token.

## Test plan
- [x] Run `sl revise` — verify the new select prompt appears with editor choice and proceed option
- [x] Choose "Proceed with the generated prompt" — verify it skips editor and shows the action menu
- [x] Choose "Review/edit the prompt" — verify editor opens as before
- [x] From action menu, choose "Re-edit the prompt" — verify editor opens on subsequent iterations
- [x] Wait for token to near expiry, run `sl revise` — verify proactive refresh occurs
- [x] Simulate expired token scenario — verify 401 retry uses force refresh

🤖 Generated with [Claude Code](https://claude.com/claude-code)