### PR TITLE
fix: sort tree siblings by created_at for deterministic ordering

### DIFF
--- a/pkg/issues/dependencies.go
+++ b/pkg/issues/dependencies.go
@@ -3,6 +3,7 @@ package issues
 import (
 	"errors"
 	"fmt"
+	"sort"
 )
 
 // Dependency-related errors
@@ -392,6 +393,11 @@ func (s *Store) buildHierarchyTree(id string, issueMap map[string]*Issue, visite
 			}
 		}
 	}
+
+	// Sort children by creation time for stable ordering
+	sort.Slice(tree.Children, func(i, j int) bool {
+		return tree.Children[i].Issue.CreatedAt.Before(tree.Children[j].Issue.CreatedAt)
+	})
 
 	return tree
 }


### PR DESCRIPTION
## Summary

Fixes #85 — `sl issue list --tree` produced non-deterministic sibling ordering on each invocation.

## Root Cause

`buildHierarchyTree()` in `pkg/issues/dependencies.go` iterates over a `map[string]*Issue` to find children of each node. Go maps have [randomized iteration order by design](https://go.dev/doc/effective_go#for), so children were appended in a different order on every call.

## Fix

Added a `sort.Slice` after collecting children to sort by `CreatedAt` ascending (4 lines, 1 file).

```go
sort.Slice(tree.Children, func(i, j int) bool {
    return tree.Children[i].Issue.CreatedAt.Before(tree.Children[j].Issue.CreatedAt)
})
```

## Alternatives Considered

| Approach | Pros | Cons | Chosen? |
|---|---|---|---|
| **Sort by `created_at`** | Simple, stable, matches phase creation order from `/specledger.tasks` | Relies on sequential creation timestamps | Yes |
| Sort by priority, then `created_at` | Groups by importance | Phases don't always differ in priority | No |
| Add explicit `order`/`sequence` field | Most flexible | Requires schema change, migration | No |
| Sort by ID | Trivial | IDs are random hashes — meaningless order | No |
| Topological sort via `blocks`/`blocked_by` | Reflects execution order | Over-engineered for display ordering; not all siblings have dependency links | No |

The `created_at` approach was chosen because `/specledger.tasks` creates feature issues sequentially (Phase 1 first, Phase 2 second, etc.), so creation timestamps naturally reflect the intended execution order.

## Test Plan

- [x] `make lint` — 0 issues
- [x] `make test` — all pass
- [ ] Manual: run `sl issue list --tree` 3+ times on a spec with multiple phases, verify stable ordering

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>