### PR TITLE
fix(ci): update codecov-action v4 config with required token

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,10 +70,10 @@ jobs:
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           file: ./coverage.out
-          fail_on_error: true
+          fail_ci_if_error: true
           verbose: true
-          display_name: codecov-umbrella
 
   lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Add `CODECOV_TOKEN` secret parameter (required for codecov-action v4)
- Fix deprecated `fail_on_error` → `fail_ci_if_error`
- Remove unnecessary `display_name` parameter

## Test plan
- [ ] Add `CODECOV_TOKEN` secret to repo settings
- [ ] Verify CI passes and coverage uploads to Codecov

🤖 Generated with [Claude Code](https://claude.com/claude-code)