### PR TITLE
ci: auto-merge dependabot PRs for minor/patch updates

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,10 +1,10 @@
 name: Dependabot Auto-Merge
 
-on: pull_request
+on:
+  pull_request:
+    branches: [ main ]
 
-permissions:
-  contents: write
-  pull-requests: write
+permissions: {}
 
 jobs:
   auto-merge:
@@ -25,7 +25,9 @@ jobs:
           github-token: ${{ steps.app-token.outputs.token }}
 
       - name: Approve and auto-merge minor/patch
-        if: steps.metadata.outputs.update-type != 'version-update:semver-major'
+        if: >-
+          steps.metadata.outputs.update-type == 'version-update:semver-minor'
+          || steps.metadata.outputs.update-type == 'version-update:semver-patch'
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           PR_URL: ${{ github.event.pull_request.html_url }}


### PR DESCRIPTION
## Summary

- Add `dependabot-auto-merge.yml` workflow that approves and enables auto-merge on Dependabot PRs for minor and patch updates
- Major version bumps are excluded and still require manual review
- Uses `gh pr merge --auto --squash` which waits for all required status checks (CI, zizmor, codecov) before merging
- Uses GitHub App token to approve PRs (Dependabot's GITHUB_TOKEN can't approve its own PRs)
- Bot actor check uses `github.event.pull_request.user.login` instead of `github.actor` to prevent spoofing (per zizmor `bot-conditions` audit)

## Test plan

- [x] zizmor passes (0 high, 0 errors)
- [x] All actions SHA-pinned with version comments
- [ ] Verify workflow triggers on existing Dependabot PRs (#137, #140)
- [ ] Confirm major version PRs (#138, #139) are NOT auto-merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)