### PR TITLE
fix: remove beads from onboarding prompt

### DIFF
--- a/.agents/commands/specledger.onboard.md
+++ b/.agents/commands/specledger.onboard.md
@@ -106,8 +106,8 @@ Present the generated tasks to the user and ask:
 > **Task Review**
 >
 > I've generated the implementation tasks. Please review them:
-> - Use `bd list --label "spec:<feature>" --limit 10` to see all tasks
-> - Use `bd dep tree --reverse <epic-id>` to see the dependency graph
+> - Use `sl issue list --all` to see all tasks
+> - Use `sl issue list --tree` to see the dependency graph
 >
 > **Would you like to proceed with implementation, or would you like to modify any tasks first?**
 

--- a/pkg/embedded/templates/specledger/commands/specledger.onboard.md
+++ b/pkg/embedded/templates/specledger/commands/specledger.onboard.md
@@ -106,8 +106,8 @@ Present the generated tasks to the user and ask:
 > **Task Review**
 >
 > I've generated the implementation tasks. Please review them:
-> - Use `bd list --label "spec:<feature>" --limit 10` to see all tasks
-> - Use `bd dep tree --reverse <epic-id>` to see the dependency graph
+> - Use `sl issue list --all` to see all tasks
+> - Use `sl issue list --tree` to see the dependency graph
 >
 > **Would you like to proceed with implementation, or would you like to modify any tasks first?**
 

--- a/specledger/specledger.yaml
+++ b/specledger/specledger.yaml
@@ -4,7 +4,7 @@ project:
     name: specledger
     short_code: sl
     created: 2026-03-23T10:48:33.458637+07:00
-    modified: 2026-03-31T15:39:04.727375+07:00
+    modified: 2026-04-04T12:35:43.968515+07:00
     version: 0.1.0
 playbook:
     name: specledger


### PR DESCRIPTION
## Summary
- Replace leftover `bd` (beads) CLI references with `sl` commands in the onboarding skill
- Updates both the agent command and the embedded template to use `sl issue list --all` and `sl issue list --tree`

## Test plan
- [x] Verified diff only touches onboarding prompt text and project timestamp
- [ ] Run `/specledger.onboard` and confirm task review step shows correct `sl` commands

Closes https://github.com/specledger/specledger/issues/131

🤖 Generated with [Claude Code](https://claude.com/claude-code)