### PR TITLE
ci: add security-events write permission to zizmor job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,6 +123,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      security-events: write
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:


### PR DESCRIPTION
## Summary
- Add `security-events: write` permission to the zizmor CI job
- Required for `codeql-action/upload-sarif` to upload SARIF results to GitHub Code Scanning

## Test plan
- [ ] Verify zizmor job completes without 403 on SARIF upload

🤖 Generated with [Claude Code](https://claude.com/claude-code)