### PR TITLE
fix: steer onboarding constitution toward design principles, not tech stack

### DIFF
--- a/.agents/commands/specledger.constitution.md
+++ b/.agents/commands/specledger.constitution.md
@@ -35,6 +35,10 @@ Follow this execution flow:
 2. Collect/derive values for placeholders:
    - If user input (conversation) supplies a value, use it.
    - Otherwise infer from existing repo context (README, docs, prior constitution versions if embedded).
+   - **IMPORTANT**: Principles must be high-level software design philosophies, NOT technology selections or stack decisions. The constitution answers "how do we approach software design?" not "what tools do we use?".
+     - **Good principles**: YAGNI, Test-First, Simplicity, Contract-Driven Design, Single Responsibility, Observability-by-Default
+     - **Not principles**: "Use Go for backends", "PostgreSQL is required", "All APIs must be REST", "React for frontends"
+     - If the audit revealed architectural patterns (e.g., monorepo, microservices), you may reference the *philosophy* behind them (e.g., "Modular boundaries — services own their data") but not mandate the specific technology.
    - For every inferred value, Group the core principles in logical groups of 4. For each group of principals, ask a multiSelect user question allowing the user to confirm or adjust each principle using the AskUserQuestion tool. Use the AskUserQuestion tool multiple times if needed to cover all principles and based on user adjustments.
    - For governance dates: `RATIFICATION_DATE` is the original adoption date (if unknown ask or mark TODO), `LAST_AMENDED_DATE` is today if changes are made, otherwise keep previous.
    - `CONSTITUTION_VERSION` must increment according to semantic versioning rules:

--- a/.agents/commands/specledger.onboard.md
+++ b/.agents/commands/specledger.onboard.md
@@ -27,8 +27,9 @@ Check if a populated project constitution exists at `.specledger/memory/constitu
 
 **If constitution is missing or unfilled** (contains `[PLACEHOLDER]` tokens or file doesn't exist):
 - Explain: "Your project doesn't have a constitution yet. Let's create one by analyzing your codebase."
-- Run `/specledger.audit` to analyze the existing codebase (languages, frameworks, patterns, conventions).
-- Run `/specledger.constitution` to propose tailored guiding principles based on the audit findings.
+- Run `/specledger.audit` to build familiarity with the codebase structure and patterns.
+- Run `/specledger.constitution` to propose guiding principles for the project.
+  - **Important**: The constitution captures high-level software design principles (e.g., YAGNI, test-first, simplicity, contract-driven design) — NOT technology selections discovered during the audit. The audit provides codebase familiarity; principles come from how the team wants to approach software design.
 - Wait for the user to review and approve the constitution before proceeding.
 
 ### Step 2: Welcome & Orientation

--- a/pkg/embedded/templates/specledger/.specledger/memory/constitution.md
+++ b/pkg/embedded/templates/specledger/.specledger/memory/constitution.md
@@ -4,29 +4,29 @@
 ## Core Principles
 
 ### [PRINCIPLE_1_NAME]
-<!-- Example: I. Library-First -->
+<!-- Example: I. Simplicity (YAGNI) -->
 [PRINCIPLE_1_DESCRIPTION]
-<!-- Example: Every feature starts as a standalone library; Libraries must be self-contained, independently testable, documented; Clear purpose required - no organizational-only libraries -->
+<!-- Example: Don't build abstractions, features, or configuration for hypothetical future needs; Start with the simplest solution that works; Add complexity only when proven necessary -->
 
 ### [PRINCIPLE_2_NAME]
-<!-- Example: II. CLI Interface -->
+<!-- Example: II. Test-First -->
 [PRINCIPLE_2_DESCRIPTION]
-<!-- Example: Every library exposes functionality via CLI; Text in/out protocol: stdin/args → stdout, errors → stderr; Support JSON + human-readable formats -->
-
-### [PRINCIPLE_3_NAME]
-<!-- Example: III. Test-First (NON-NEGOTIABLE) -->
-[PRINCIPLE_3_DESCRIPTION]
 <!-- Example: TDD mandatory: Tests written → User approved → Tests fail → Then implement; Red-Green-Refactor cycle strictly enforced -->
 
+### [PRINCIPLE_3_NAME]
+<!-- Example: III. Contract-Driven Design -->
+[PRINCIPLE_3_DESCRIPTION]
+<!-- Example: API contracts are the source of truth; Changes to contracts require explicit review; Consumers and producers agree on interfaces before implementation -->
+
 ### [PRINCIPLE_4_NAME]
-<!-- Example: IV. Integration Testing -->
+<!-- Example: IV. Single Responsibility -->
 [PRINCIPLE_4_DESCRIPTION]
-<!-- Example: Focus areas requiring integration tests: New library contract tests, Contract changes, Inter-service communication, Shared schemas -->
+<!-- Example: Each module/service owns one concern; Clear boundaries between domains; Shared logic extracted only when duplication is proven across three or more consumers -->
 
 ### [PRINCIPLE_5_NAME]
-<!-- Example: V. Observability, VI. Versioning & Breaking Changes, VII. Simplicity -->
+<!-- Example: V. Observability-by-Default -->
 [PRINCIPLE_5_DESCRIPTION]
-<!-- Example: Text I/O ensures debuggability; Structured logging required; Or: MAJOR.MINOR.BUILD format; Or: Start simple, YAGNI principles -->
+<!-- Example: Every service must be observable from day one; Structured logging, health checks, and metrics are not afterthoughts but built into the design -->
 
 ## [SECTION_2_NAME]
 <!-- Example: Additional Constraints, Security Requirements, Performance Standards, etc. -->

--- a/pkg/embedded/templates/specledger/commands/specledger.constitution.md
+++ b/pkg/embedded/templates/specledger/commands/specledger.constitution.md
@@ -35,6 +35,10 @@ Follow this execution flow:
 2. Collect/derive values for placeholders:
    - If user input (conversation) supplies a value, use it.
    - Otherwise infer from existing repo context (README, docs, prior constitution versions if embedded).
+   - **IMPORTANT**: Principles must be high-level software design philosophies, NOT technology selections or stack decisions. The constitution answers "how do we approach software design?" not "what tools do we use?".
+     - **Good principles**: YAGNI, Test-First, Simplicity, Contract-Driven Design, Single Responsibility, Observability-by-Default
+     - **Not principles**: "Use Go for backends", "PostgreSQL is required", "All APIs must be REST", "React for frontends"
+     - If the audit revealed architectural patterns (e.g., monorepo, microservices), you may reference the *philosophy* behind them (e.g., "Modular boundaries — services own their data") but not mandate the specific technology.
    - For every inferred value, Group the core principles in logical groups of 4. For each group of principals, ask a multiSelect user question allowing the user to confirm or adjust each principle using the AskUserQuestion tool. Use the AskUserQuestion tool multiple times if needed to cover all principles and based on user adjustments.
    - For governance dates: `RATIFICATION_DATE` is the original adoption date (if unknown ask or mark TODO), `LAST_AMENDED_DATE` is today if changes are made, otherwise keep previous.
    - `CONSTITUTION_VERSION` must increment according to semantic versioning rules:

--- a/pkg/embedded/templates/specledger/commands/specledger.onboard.md
+++ b/pkg/embedded/templates/specledger/commands/specledger.onboard.md
@@ -27,8 +27,9 @@ Check if a populated project constitution exists at `.specledger/memory/constitu
 
 **If constitution is missing or unfilled** (contains `[PLACEHOLDER]` tokens or file doesn't exist):
 - Explain: "Your project doesn't have a constitution yet. Let's create one by analyzing your codebase."
-- Run `/specledger.audit` to analyze the existing codebase (languages, frameworks, patterns, conventions).
-- Run `/specledger.constitution` to propose tailored guiding principles based on the audit findings.
+- Run `/specledger.audit` to build familiarity with the codebase structure and patterns.
+- Run `/specledger.constitution` to propose guiding principles for the project.
+  - **Important**: The constitution captures high-level software design principles (e.g., YAGNI, test-first, simplicity, contract-driven design) — NOT technology selections discovered during the audit. The audit provides codebase familiarity; principles come from how the team wants to approach software design.
 - Wait for the user to review and approve the constitution before proceeding.
 
 ### Step 2: Welcome & Orientation


### PR DESCRIPTION
## Summary
- Add explicit guardrails to `specledger.onboard` and `specledger.constitution` prompts to steer constitution generation toward high-level software design principles (YAGNI, Test-First, Contract-Driven Design) instead of tech stack selections ("Use Go", "PostgreSQL required")
- Reframe the audit→constitution handoff: audit provides codebase familiarity, principles come from design philosophy
- Update constitution template examples to model the correct abstraction level

Closes #91

## Test plan
- [x] `make lint` and `make test` pass
- [x] Run `sl init` in a fresh repo → verify onboarding proposes design principles, not tech stack facts
- [x] Verify `sl doctor --template` correctly syncs the updated embedded templates to `.agents/commands/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)