### PR TITLE
fix(skills): add verify and checkpoint prompts to spec-driven workflow

### DIFF
--- a/.agents/commands/specledger.checkpoint.md
+++ b/.agents/commands/specledger.checkpoint.md
@@ -1,5 +1,5 @@
 ---
-description: Critical divergence review — compare implementation against plan artifacts, flag force-closed issues, and surface gaps. Updates session log at FEATURE_DIR/sessions/<spec>-checkpoint.md
+description: Critical divergence review — compare implementation against plan artifacts, flag force-closed issues, and surface gaps. Updates session log at FEATURE_DIR/sessions/<branch-name>-checkpoint.md
 ---
 
 ## User Input
@@ -102,9 +102,12 @@ Execution steps:
    - **conscious**: Divergence is documented somewhere (issue notes, decision log, commit message)
    - **oversight**: No documentation found — this was likely missed
 
-6. Update session log at `FEATURE_DIR/sessions/<spec>-checkpoint.md`:
+6. Update session log:
    - Create `FEATURE_DIR/sessions/` directory if it doesn't exist
-   - Append timestamped entry using the format below
+   - **Determine output file based on scope**:
+     - **Phase-scoped checkpoint**: If `$ARGUMENTS` indicates a phase scope (e.g., `"Verify phase:setup issues only"`), write to `FEATURE_DIR/sessions/<branch-name>-checkpoint-<phase-name>.md`. One file per phase, overwriting any prior phase-scoped checkpoint for the same phase.
+     - **Full checkpoint** (no phase scope): Append a timestamped entry to `FEATURE_DIR/sessions/<branch-name>-checkpoint.md`.
+   - Use the entry format below
 
    ```markdown
    ## Divergence Review: YYYY-MM-DD HH:MM
@@ -225,7 +228,7 @@ Execution steps:
 
 ## Session Log Format
 
-Session logs are stored at `FEATURE_DIR/sessions/<spec>-checkpoint.md`:
+Session logs are stored at `FEATURE_DIR/sessions/<branch-name>-checkpoint.md`:
 
 ```markdown
 # Session Log: <branch-name>

--- a/.agents/commands/specledger.checkpoint.md
+++ b/.agents/commands/specledger.checkpoint.md
@@ -1,5 +1,5 @@
 ---
-description: Critical divergence review — compare implementation against plan artifacts, flag force-closed issues, and surface gaps. Updates session log at .specledger/sessions/<spec>-session.md
+description: Critical divergence review — compare implementation against plan artifacts, flag force-closed issues, and surface gaps. Updates session log at FEATURE_DIR/sessions/<spec>-checkpoint.md
 ---
 
 ## User Input
@@ -102,8 +102,8 @@ Execution steps:
    - **conscious**: Divergence is documented somewhere (issue notes, decision log, commit message)
    - **oversight**: No documentation found — this was likely missed
 
-6. Update session log at `.specledger/sessions/<branch>-session.md`:
-   - Create directory if it doesn't exist
+6. Update session log at `FEATURE_DIR/sessions/<spec>-checkpoint.md`:
+   - Create `FEATURE_DIR/sessions/` directory if it doesn't exist
    - Append timestamped entry using the format below
 
    ```markdown
@@ -225,7 +225,7 @@ Execution steps:
 
 ## Session Log Format
 
-Session logs are stored at `.specledger/sessions/<branch>-session.md`:
+Session logs are stored at `FEATURE_DIR/sessions/<spec>-checkpoint.md`:
 
 ```markdown
 # Session Log: <branch-name>

--- a/.agents/commands/specledger.clarify.md
+++ b/.agents/commands/specledger.clarify.md
@@ -174,7 +174,7 @@ Execution steps:
 Behavior rules:
 
 - If no meaningful ambiguities found (or all potential questions would be low-impact), respond: "No critical ambiguities detected worth formal clarification." and suggest proceeding.
-- If spec file missing, instruct user to run `/specledger.specledger` first (do not create a new spec here).
+- If spec file missing, instruct user to run `/specledger.specify` first (do not create a new spec here).
 - Never exceed 10 total asked questions (clarification retries for a single question do not count as new questions).
 - Avoid speculative tech stack questions unless the absence blocks functional clarity.
 - Respect user early termination signals ("stop", "done", "proceed").

--- a/.agents/commands/specledger.constitution.md
+++ b/.agents/commands/specledger.constitution.md
@@ -2,7 +2,7 @@
 description: Create or update the project constitution from interactive or provided principle inputs, ensuring all dependent templates stay in sync.
 handoffs: 
   - label: Build Specification
-    agent: specledger.specledger
+    agent: specledger.specify
     prompt: Implement the feature specification based on the updated constitution. I want to build...
 ---
 

--- a/.agents/commands/specledger.implement.md
+++ b/.agents/commands/specledger.implement.md
@@ -68,13 +68,30 @@ Execute the implementation plan by processing all tasks in tasks.md. This comman
      * **STOP** and use AskUserQuestion to ask: "Some checklists are incomplete. Do you want to proceed with implementation anyway? (yes/no)"
      * Wait for user response before continuing
      * If user says "no" or "wait" or "stop", halt execution
-     * If user says "yes" or "proceed" or "continue", proceed to step 4
+     * If user says "yes" or "proceed" or "continue", proceed to step 5
 
     - **If all checklists are complete**:
       * Display the table showing all checklists passed
       * Automatically proceed to step 5
 
-5. Load and analyze the implementation context:
+5. **Pre-flight review check** (verify review detection):
+
+   Check if `FEATURE_DIR/reviews/` contains any review files (written by `/specledger.verify`).
+
+   **If a review file exists**: Proceed silently — verification was already completed.
+
+   **If no review file exists**: Use AskUserQuestion to ask:
+
+   > **No Verify Review Found**
+   >
+   > No verification review was found in `FEATURE_DIR/reviews/`. It is **strongly recommended** to run `/specledger.verify` at least once before implementing — this catches spec/plan/task consistency issues that are much harder to fix during implementation.
+   >
+   > **Would you like to run `/specledger.verify` now, or proceed without a review?**
+
+   If the user chooses to verify, pause implementation and run `/specledger.verify`. Resume implementation after verification completes.
+   If the user chooses to proceed, continue — but note in the execution log that verification was skipped.
+
+6. Load and analyze the implementation context:
    - **REQUIRED**: Read tasks.md for the complete task list and execution plan
    - **REQUIRED**: Read plan.md for tech stack, architecture, and file structure
    - **IF EXISTS**: Read data-model.md for entities and relationships
@@ -82,7 +99,7 @@ Execute the implementation plan by processing all tasks in tasks.md. This comman
    - **IF EXISTS**: Read research.md for technical decisions and constraints
    - **IF EXISTS**: Read quickstart.md for integration scenarios
 
-6. **Project Setup Verification**:
+7. **Project Setup Verification**:
    - **REQUIRED**: Create/verify ignore files based on actual project setup:
 
    **Detection & Creation Logic**:
@@ -116,26 +133,35 @@ Execute the implementation plan by processing all tasks in tasks.md. This comman
    - **Prettier**: `node_modules/`, `dist/`, `build/`, `coverage/`, `package-lock.json`, `yarn.lock`, `pnpm-lock.yaml`
     - **Terraform**: `.terraform/`, `*.tfstate*`, `*.tfvars`, `.terraform.lock.hcl`
 
-7. Read tasks.md structure and extract:
+8. Read tasks.md structure and extract:
    - **Task phases**: Setup, Tests, Core, Integration, Polish
    - **Task dependencies**: Sequential vs parallel execution rules
    - **Task details**: ID, description, file paths, design + acceptance criteria
    - **Task comments**: Important notes and modifications to original plan
    - **Execution flow**: Order and dependency requirements
 
-8. Execute implementation following the task plan:
+9. Execute implementation following the task plan:
    - **Phase-by-phase execution**: Complete each phase before moving to the next
    - **Respect dependencies**: Run sequential tasks in order, parallel tasks [P] can run together
    - **Follow TDD approach**: Execute test tasks before their corresponding implementation tasks
    - **File-based coordination**: Tasks affecting the same files must run sequentially
    - **Validation checkpoints**: Verify each phase completion before proceeding
+   - **Phase checkpoint suggestion**: After completing all tasks in a phase, check if this phase has already been covered by a previous checkpoint (look for existing checkpoint files in `FEATURE_DIR/sessions/`). If not already checkpointed, use AskUserQuestion to suggest a scoped checkpoint:
+
+     > **Phase "[phase name]" Complete**
+     >
+     > All tasks in this phase are closed. You can run a scoped `/specledger.checkpoint` to verify issues and DoD for this phase before continuing.
+     >
+     > **Run scoped checkpoint for this phase, or continue to the next phase?**
+
+     If the user accepts, run `/specledger.checkpoint "Verify phase:[phase-name] issues only — phase completed this session"`. If the user skips, proceed to the next phase.
    - **Read issue fields before implementation**:
      - Use `sl issue show <id>` to retrieve the issue's details
      - Read the `design` field for technical approach and file references
       - Read the `acceptance_criteria` field for requirements and success criteria
       - Use these fields to guide implementation decisions
 
-9. Implementation execution rules:
+10. Implementation execution rules:
    - **Setup first**: Initialize project structure, dependencies, configuration
    - **Tests before code**: If you need to write tests for contracts, entities, and integration scenarios
    - **Core development**: Implement models, services, CLI commands, endpoints
@@ -145,7 +171,7 @@ Execute the implementation plan by processing all tasks in tasks.md. This comman
    - **Check off DoD items progressively**: As subtasks complete, use `sl issue update <id> --check-dod "Item text"` to mark relevant DoD items as verified
     - **Only close after all DoD items checked**: Ensure all Definition of Done items are marked complete before closing an issue
 
-10. Progress tracking and error handling:
+11. Progress tracking and error handling:
    - Find ready tasks using: `sl issue ready`
    - If no ready tasks, display blocking issues and offer options
    - Update issue status with: `sl issue update <id> --status in_progress`
@@ -156,7 +182,7 @@ Execute the implementation plan by processing all tasks in tasks.md. This comman
    - Suggest next steps if implementation cannot proceed
     - **IMPORTANT** For completed tasks, make sure to close the issue: `sl issue close <id> --reason "Completed"`
 
-10a. **Definition of Done Verification** (before closing issues):
+11a. **Definition of Done Verification** (before closing issues):
 
    Before closing any issue, verify its Definition of Done items:
 
@@ -197,12 +223,29 @@ Execute the implementation plan by processing all tasks in tasks.md. This comman
        Proceed with closing? (--force required)
        ```
 
-11. Completion validation:
+12. Completion validation:
    - Verify all required tasks are completed
    - Check that implemented features match the original specification
    - Validate that tests pass and coverage meets requirements
    - Confirm the implementation follows the technical plan
    - Report final status with summary of completed work
+
+13. **Post-Implementation Checkpoint** (strongly recommended):
+
+   After all tasks are complete and the completion summary is presented, use AskUserQuestion to ask:
+
+   > **All Tasks Complete — Checkpoint Strongly Recommended**
+   >
+   > Implementation is finished. Before merging or considering this feature done, it is **strongly recommended** to run `/specledger.checkpoint` for a critical divergence review. The checkpoint will:
+   > - Compare implementation against spec, plan, and task artifacts
+   > - Flag any force-closed issues with unchecked Definition of Done items
+   > - Surface coverage gaps and plan drift
+   > - Offer an independent adversarial review agent for a fresh-eyes code review
+   >
+   > **Would you like to run the checkpoint now?**
+
+   If the user accepts, invoke `/specledger.checkpoint`.
+   If the user declines, note in the completion summary that the post-implementation checkpoint was skipped.
 
 ## Issue Tracking Commands
 
@@ -221,7 +264,7 @@ Use the built-in `sl issue` commands for issue management:
 
 ## Definition of Done
 
-Before closing an issue, verify the Definition of Done criteria using the verification process in step 9a:
+Before closing an issue, verify the Definition of Done criteria using the verification process in step 11a:
 
 ### Verification Process
 

--- a/.agents/commands/specledger.implement.md
+++ b/.agents/commands/specledger.implement.md
@@ -146,7 +146,7 @@ Execute the implementation plan by processing all tasks in tasks.md. This comman
    - **Follow TDD approach**: Execute test tasks before their corresponding implementation tasks
    - **File-based coordination**: Tasks affecting the same files must run sequentially
    - **Validation checkpoints**: Verify each phase completion before proceeding
-   - **Phase checkpoint suggestion**: After completing all tasks in a phase, check if this phase has already been covered by a previous checkpoint (look for existing checkpoint files in `FEATURE_DIR/sessions/`). If not already checkpointed, use AskUserQuestion to suggest a scoped checkpoint:
+   - **Phase checkpoint suggestion**: After completing all tasks in a phase, check if this specific phase has already been checkpointed by looking for `FEATURE_DIR/sessions/<branch-name>-checkpoint-<phase-name>.md`. If that file does not exist, use AskUserQuestion to suggest a scoped checkpoint:
 
      > **Phase "[phase name]" Complete**
      >

--- a/.agents/commands/specledger.onboard.md
+++ b/.agents/commands/specledger.onboard.md
@@ -32,6 +32,16 @@ Check if a populated project constitution exists at `.specledger/memory/constitu
   - **Important**: The constitution captures high-level software design principles (e.g., YAGNI, test-first, simplicity, contract-driven design) — NOT technology selections discovered during the audit. The audit provides codebase familiarity; principles come from how the team wants to approach software design.
 - Wait for the user to review and approve the constitution before proceeding.
 
+**Commit Suggestion**: After the constitution is created or confirmed, use AskUserQuestion to suggest:
+
+> **Constitution Ready — Commit Setup?**
+>
+> Your project constitution is in place. It's a good idea to commit this setup before starting feature work.
+>
+> **Would you like to commit the constitution and setup files now?**
+
+If the user accepts, commit the constitution and any setup files. If skipped, proceed to Step 2.
+
 ### Step 2: Welcome & Orientation
 
 Present a brief welcome message:
@@ -44,7 +54,9 @@ Present a brief welcome message:
 > 3. **Plan** - Design the implementation approach
 > 4. **Tasks** - Generate actionable, ordered tasks
 > 5. **Review** - You review tasks before any code is written
-> 6. **Implement** - Execute the tasks
+> 6. **Verify** - Cross-check spec/plan/task consistency (recommended)
+> 7. **Implement** - Execute the tasks
+> 8. **Checkpoint** - Review implementation against plan (recommended)
 >
 > Let's start by describing your first feature!
 
@@ -59,8 +71,9 @@ Before we begin, here's a quick reference of the available SpecLedger commands:
 | `/specledger.clarify` | Resolve ambiguities and answer spec questions |
 | `/specledger.plan` | Generate technical implementation plan |
 | `/specledger.tasks` | Create ordered, dependency-linked task list |
-| `/specledger.implement` | Execute implementation tasks in order |
 | `/specledger.verify` | Cross-artifact consistency and quality check |
+| `/specledger.implement` | Execute implementation tasks in order |
+| `/specledger.checkpoint` | Divergence review during/after implementation |
 
 **Utility Commands:**
 | Command | Description |
@@ -114,15 +127,53 @@ Present the generated tasks to the user and use AskUserQuestion to ask:
 >
 > **Would you like to proceed with implementation, or would you like to modify any tasks first?**
 
+### Step 8.5: Verification (Recommended)
+
+After the user approves the tasks, recommend running verification before implementation.
+
+Use AskUserQuestion to ask:
+
+> **Pre-Implementation Verification**
+>
+> Before we start coding, it's strongly recommended to run `/specledger.verify` to check that your spec, plan, and tasks are consistent and complete. At least one verify review should exist before implementation begins.
+>
+> **Would you like to run verification now, or skip and go straight to implementation?**
+
+If the user chooses to verify:
+- Run `/specledger.verify` to perform cross-artifact consistency analysis.
+- If CRITICAL issues are found, recommend resolving them before proceeding.
+- After verification completes (or if only LOW/MEDIUM issues), ask if they want to proceed to implementation.
+
+If the user skips, proceed directly to Step 9.
+
 ### Step 9: Implementation
 
 Only after the user has reviewed and approved the tasks:
 
 Run `/specledger.implement` to begin executing the tasks in order.
 
+### Step 10: Post-Implementation Checkpoint (Recommended)
+
+After implementation completes, recommend a checkpoint review.
+
+Use AskUserQuestion to ask:
+
+> **Implementation Complete — Checkpoint Recommended**
+>
+> All tasks have been implemented. Before wrapping up, it's strongly recommended to run `/specledger.checkpoint` for a divergence review. This will compare your implementation against the plan, flag any gaps, and offer an adversarial code review.
+>
+> **Would you like to run a checkpoint now?**
+
+If the user accepts:
+- Run `/specledger.checkpoint` to perform the divergence review.
+- If the checkpoint offers an adversarial review agent, let the user decide whether to run it.
+
+If the user declines, summarize what was completed and note the checkpoint was skipped.
+
 ## Important Notes
 
 - **Never skip the review pause** in Step 8. The user must always approve tasks before implementation begins.
+- **Verify and checkpoint are optional but recommended.** If a user skips them during onboarding, note that they can always run `/specledger.verify` or `/specledger.checkpoint` independently later.
 - If the user wants to modify tasks, help them update the specledger issues before proceeding.
 - If the user wants to stop at any point, respect that and summarize what was completed.
 - Each step builds on the previous one - don't skip steps unless the user explicitly asks.

--- a/.agents/commands/specledger.onboard.md
+++ b/.agents/commands/specledger.onboard.md
@@ -84,6 +84,38 @@ Before we begin, here's a quick reference of the available SpecLedger commands:
 **Skills (auto-loaded context):**
 - `sl-issue-tracking` - Issue management patterns and best practices
 - `sl-audit` - Codebase reconnaissance and module discovery
+- `sl-skill` - Agent skill discovery, installation, and management
+
+### Step 2.6: Skill Discovery (Optional)
+
+Search the skills.sh registry for agent skills relevant to this project's technology stack.
+
+**If Step 1 performed an audit**: Extract the 2-3 primary technologies identified during the audit (e.g., the language, primary framework, and database).
+
+**If Step 1 skipped the audit** (constitution already existed): Use AskUserQuestion to ask whether the user would like to run a quick codebase audit to discover technologies and search for relevant agent skills from the skills.sh registry. If they accept, run `/specledger.audit` and extract technologies from the results. If they decline, wait for user to describe what skills to search for or directly proceed to Step 3.
+
+Once technologies are identified:
+
+1. For each technology, run: `sl skill search "<technology>" --limit 3`
+2. Collect unique results across all searches (deduplicate by skill name).
+3. If results were found, present a compact table:
+
+   > **Recommended Skills for your stack**
+   >
+   > | # | Skill | Source |
+   > |---|-------|--------|
+   > | 1 | skill-name | owner/repo |
+   > | 2 | skill-name | owner/repo |
+   >
+   > These skills provide agent context for working with your project's technologies.
+
+4. Use AskUserQuestion with multi select: "Would you like to install any of these skills?"
+5. If the user selects skills, run `sl skill add <source> -y` for each selected skill.
+6. If the user declines, proceed to Step 3 immediately.
+
+**Error handling**: If `sl skill search` or `sl skill add` fails (network error, API unavailable), notify the user and suggest they can try manually later with `sl skill search "<technology>"`. Do not retry — proceed to Step 3.
+
+If no relevant skills are found, mention no skills were found and suggest proceeding to Step 3.
 
 ### Step 3: Feature Description
 

--- a/.agents/commands/specledger.plan.md
+++ b/.agents/commands/specledger.plan.md
@@ -97,7 +97,18 @@ Generate an implementation plan from the feature specification. This includes te
    - Adds only new technology from current plan
    - Preserves manual additions between markers
 
-**Output**: data-model.md, /contracts/*, quickstart.md, agent-specific file
+4. **Skill suggestions** (optional, non-blocking):
+   - Extract technology keywords from the Technical Context fields just filled
+     (Language, PrimaryDeps, Storage, Testing — skip generic terms like "files" or "N/A").
+   - For the 1-2 most specific technologies, run: `sl skill search "<technology>" --limit 5`
+   - Cross-reference results with `sl skill list --json` to exclude already-installed skills.
+   - If new skills are found, present them briefly and use AskUserQuestion with multi select.
+   - If user accepts, run `sl skill add <source> -y` for each.
+   - If user declines or no new skills found, continue immediately.
+   - **Error handling**: If `sl skill search` or `sl skill add` fails, notify the user and suggest they can try manually later with `sl skill search "<technology>"`. Do not retry.
+   - Do NOT block Phase 1 completion on this step.
+
+**Output**: data-model.md, /contracts/*, quickstart.md, agent-specific file, (optional) installed skills
 
 ## Key rules
 

--- a/.agents/commands/specledger.specify.md
+++ b/.agents/commands/specledger.specify.md
@@ -30,7 +30,7 @@ Create feature specifications from natural language descriptions. This is the st
 
 ## Outline
 
-The text the user typed after `/specledger.specledger` in the triggering message **is** the feature description. Assume you always have it available in this conversation even if `$ARGUMENTS` appears literally below. Do not ask the user to repeat it unless they provided an empty command.
+The text the user typed after `/specledger.specify` in the triggering message **is** the feature description. Assume you always have it available in this conversation even if `$ARGUMENTS` appears literally below. Do not ask the user to repeat it unless they provided an empty command.
 
 Given that feature description, do this:
 

--- a/.agents/commands/specledger.tasks.md
+++ b/.agents/commands/specledger.tasks.md
@@ -1,10 +1,9 @@
 ---
 description: Generate an actionable, dependency-ordered tasks.md for the feature based on available design artifacts.
 handoffs:
-  - label: Analyze For Consistency
-    agent: specledger.analyze
-    prompt: Run a project analysis for consistency
-    send: true
+  - label: Verify For Consistency
+    agent: specledger.verify
+    prompt: Run a cross-artifact consistency and quality verification
   - label: Implement Project
     agent: specledger.implement
     prompt: Start the implementation in phases
@@ -128,6 +127,22 @@ Generate actionable, dependency-ordered tasks from the implementation plan. Task
    - Parallel opportunities identified
    - Independent test criteria for each story
    - Suggested MVP (usually US1 or first P1 story)
+
+7. **Pre-Implementation Verify Check** (strongly recommended):
+
+   After presenting the report, check if `FEATURE_DIR/reviews/` contains any review files.
+
+   **If a review file exists**: Skip this prompt — verification was already completed. Proceed to implementation handoff.
+
+   **If no review file exists**: Use AskUserQuestion to ask:
+
+   > **Verification Strongly Recommended**
+   >
+   > At least one verify review should exist before implementation begins. Running `/specledger.verify` will cross-check your spec, plan, and tasks for consistency gaps, coverage issues, and ambiguities — catching problems now is far cheaper than finding them during implementation.
+   >
+   > **Would you like to run `/specledger.verify` now? (Strongly recommended)**
+
+   If the user accepts, the handoff to `specledger.verify` handles execution. If the user skips, proceed to the `specledger.implement` handoff — but note in the summary that verification was skipped.
 
 Context for task generation: $ARGUMENTS
 

--- a/.agents/commands/specledger.verify.md
+++ b/.agents/commands/specledger.verify.md
@@ -170,11 +170,36 @@ At end of report, output a concise Next Actions block:
 
 - If CRITICAL issues exist: Recommend resolving before `/specledger.implement`
 - If only LOW/MEDIUM: User may proceed, but provide improvement suggestions
-- Provide explicit command suggestions: e.g., "Run /specledger.specledger with refinement", "Run /specledger.plan to adjust architecture", "Manually edit tasks.md to add coverage for 'performance-metrics'"
+- Provide explicit command suggestions: e.g., "Run /specledger.specify with refinement", "Run /specledger.plan to adjust architecture", "Manually edit tasks.md to add coverage for 'performance-metrics'"
 
 ### 8. Offer Remediation
 
 Use the AskUserQuestion tool to ask: "Would you like me to suggest concrete remediation edits for the top N issues?" (Do NOT apply them automatically.)
+
+### 9. Persist Review Report (Recommended)
+
+After the analysis is complete and any remediation discussion is finished, offer to save the review.
+
+Use AskUserQuestion to ask: **"Would you like to save this review to `FEATURE_DIR/reviews/<spec-number>-review.md`?"** (Recommended — at least one review should exist before implementation begins.)
+
+**If the user accepts:**
+1. Create the `FEATURE_DIR/reviews/` directory if it doesn't exist
+2. Write the full analysis report (findings table, coverage summary, constitution alignment, unmapped tasks, metrics, and next actions) to `FEATURE_DIR/reviews/<spec-number>-review.md` (e.g., `006-review.md`)
+3. Include a YAML frontmatter header with date and summary metrics:
+   ```yaml
+   ---
+   date: YYYY-MM-DD
+   total_requirements: N
+   total_tasks: N
+   coverage_pct: N%
+   critical_issues: N
+   ---
+   ```
+4. Confirm the file was written and its path
+
+**If the user declines:** Note that no review file was persisted. The `/specledger.tasks` and `/specledger.implement` skills check for review files and will prompt again before implementation.
+
+**IMPORTANT**: The analysis itself (steps 1-8) remains **strictly read-only**. This file write is a separate, explicit opt-in step that happens only after analysis is complete.
 
 ## Operating Principles
 
@@ -187,7 +212,7 @@ Use the AskUserQuestion tool to ask: "Would you like me to suggest concrete reme
 
 ### Analysis Guidelines
 
-- **NEVER modify files** (this is read-only analysis)
+- **NEVER modify files during analysis** (steps 1-8 are strictly read-only; step 9 is an explicit opt-in write)
 - **NEVER hallucinate missing sections** (if absent, report them accurately)
 - **Prioritize constitution violations** (these are always CRITICAL)
 - **Use examples over exhaustive rules** (cite specific instances, not generic patterns)

--- a/GUIDELINES.md
+++ b/GUIDELINES.md
@@ -53,9 +53,9 @@ Run `/specledger.tasks` to generate the task breakdown.
 
 **Important: Generate tasks cleanly.** The task generation should produce a clean `tasks.md` file with dependency-ordered tasks. Do not use `sl issue` commands during task generation — the tasks file is the source of truth at this stage.
 
-## Stage 4: Analyze (Before Implementation)
+## Stage 4: Verify (Before Implementation)
 
-**Always run `/specledger.analyze` after task generation and before implementation.** This is a critical quality gate.
+**Always run `/specledger.verify` after task generation and before implementation.** This is a critical quality gate.
 
 The analyze command performs a read-only cross-artifact consistency check across `spec.md`, `plan.md`, and `tasks.md`. It will identify:
 
@@ -72,7 +72,7 @@ The analyze command performs a read-only cross-artifact consistency check across
 - **HIGH issues** — should be resolved; skip only with explicit justification
 - **MEDIUM/LOW issues** — resolve if time permits; document as known gaps if skipping
 
-If the analysis reveals gaps, update the relevant artifacts (spec, plan, or tasks) and re-run `/specledger.analyze` to confirm fixes.
+If the analysis reveals gaps, update the relevant artifacts (spec, plan, or tasks) and re-run `/specledger.verify` to confirm fixes.
 
 ## Stage 5: Final Review Before Implementation
 
@@ -140,8 +140,8 @@ The more specific your constraints and questions, the deeper the research agents
 | Specify   | `/specledger.specify`   | Yes - UI review     | Spec covers all requirements |
 | Clarify   | `/specledger.clarify`   | Optional            | Ambiguities resolved         |
 | Plan      | `/specledger.plan`      | Yes - UI review     | Architecture decisions sound |
-| Tasks     | `/specledger.tasks`     | After analyze       | Tasks are dependency-ordered |
-| Analyze   | `/specledger.analyze`   | Yes - UI review     | No CRITICAL gaps             |
+| Tasks     | `/specledger.tasks`     | After verify        | Tasks are dependency-ordered |
+| Verify    | `/specledger.verify`    | Yes - UI review     | No CRITICAL gaps             |
 | Revise    | `/specledger.revise`    | After each cycle    | All comments addressed       |
 | Implement | `/specledger.implement` | Post-implementation | Features match spec          |
 

--- a/GUIDELINES.md
+++ b/GUIDELINES.md
@@ -5,7 +5,7 @@ Best practices for using SpecLedger to build features methodically with human-in
 ## Core Workflow
 
 ```
-specify → UI review → revise → plan → UI review → revise → tasks → analyze → UI review → revise → implement
+specify → UI review → revise → plan → UI review → revise → tasks → verify → UI review → revise → implement
 ```
 
 Every stage produces artifacts that **must be reviewed in the SpecLedger UI** before proceeding. Never skip the review step.
@@ -57,7 +57,7 @@ Run `/specledger.tasks` to generate the task breakdown.
 
 **Always run `/specledger.verify` after task generation and before implementation.** This is a critical quality gate.
 
-The analyze command performs a read-only cross-artifact consistency check across `spec.md`, `plan.md`, and `tasks.md`. It will identify:
+The verify command performs a read-only cross-artifact consistency check across `spec.md`, `plan.md`, and `tasks.md`. It will identify:
 
 - Requirements with no associated tasks (coverage gaps)
 - Tasks with no mapped requirement (orphan tasks)
@@ -76,7 +76,7 @@ If the analysis reveals gaps, update the relevant artifacts (spec, plan, or task
 
 ## Stage 5: Final Review Before Implementation
 
-After analyze passes cleanly:
+After verify passes cleanly:
 
 1. Push all artifacts and review the complete task list in the UI
 2. Verify task ordering, dependencies, and acceptance criteria make sense
@@ -148,7 +148,7 @@ The more specific your constraints and questions, the deeper the research agents
 ## Anti-Patterns
 
 - **Skipping UI review** — Running specify-plan-tasks-implement without human review produces misaligned features
-- **Skipping analyze** — Going straight from tasks to implement misses coverage gaps and inconsistencies
+- **Skipping verify** — Going straight from tasks to implement misses coverage gaps and inconsistencies
 - **Vague prompts** — "Build a login page" produces a shallow spec; provide constraints, edge cases, and user context
-- **Ignoring CRITICAL findings** — Analyze flags them for a reason; resolve before implementing
+- **Ignoring CRITICAL findings** — Verify flags them for a reason; resolve before implementing
 - **Using issue tracking during task generation** — Keep task generation clean; issue tracking starts during implementation

--- a/pkg/embedded/templates/specledger/commands/specledger.checkpoint.md
+++ b/pkg/embedded/templates/specledger/commands/specledger.checkpoint.md
@@ -1,5 +1,5 @@
 ---
-description: Critical divergence review — compare implementation against plan artifacts, flag force-closed issues, and surface gaps. Updates session log at FEATURE_DIR/sessions/<spec>-checkpoint.md
+description: Critical divergence review — compare implementation against plan artifacts, flag force-closed issues, and surface gaps. Updates session log at FEATURE_DIR/sessions/<branch-name>-checkpoint.md
 ---
 
 ## User Input
@@ -102,9 +102,12 @@ Execution steps:
    - **conscious**: Divergence is documented somewhere (issue notes, decision log, commit message)
    - **oversight**: No documentation found — this was likely missed
 
-6. Update session log at `FEATURE_DIR/sessions/<spec>-checkpoint.md`:
+6. Update session log:
    - Create `FEATURE_DIR/sessions/` directory if it doesn't exist
-   - Append timestamped entry using the format below
+   - **Determine output file based on scope**:
+     - **Phase-scoped checkpoint**: If `$ARGUMENTS` indicates a phase scope (e.g., `"Verify phase:setup issues only"`), write to `FEATURE_DIR/sessions/<branch-name>-checkpoint-<phase-name>.md`. One file per phase, overwriting any prior phase-scoped checkpoint for the same phase.
+     - **Full checkpoint** (no phase scope): Append a timestamped entry to `FEATURE_DIR/sessions/<branch-name>-checkpoint.md`.
+   - Use the entry format below
 
    ```markdown
    ## Divergence Review: YYYY-MM-DD HH:MM
@@ -225,7 +228,7 @@ Execution steps:
 
 ## Session Log Format
 
-Session logs are stored at `FEATURE_DIR/sessions/<spec>-checkpoint.md`:
+Session logs are stored at `FEATURE_DIR/sessions/<branch-name>-checkpoint.md`:
 
 ```markdown
 # Session Log: <branch-name>

--- a/pkg/embedded/templates/specledger/commands/specledger.checkpoint.md
+++ b/pkg/embedded/templates/specledger/commands/specledger.checkpoint.md
@@ -1,5 +1,5 @@
 ---
-description: Critical divergence review — compare implementation against plan artifacts, flag force-closed issues, and surface gaps. Updates session log at .specledger/sessions/<spec>-session.md
+description: Critical divergence review — compare implementation against plan artifacts, flag force-closed issues, and surface gaps. Updates session log at FEATURE_DIR/sessions/<spec>-checkpoint.md
 ---
 
 ## User Input
@@ -102,8 +102,8 @@ Execution steps:
    - **conscious**: Divergence is documented somewhere (issue notes, decision log, commit message)
    - **oversight**: No documentation found — this was likely missed
 
-6. Update session log at `.specledger/sessions/<branch>-session.md`:
-   - Create directory if it doesn't exist
+6. Update session log at `FEATURE_DIR/sessions/<spec>-checkpoint.md`:
+   - Create `FEATURE_DIR/sessions/` directory if it doesn't exist
    - Append timestamped entry using the format below
 
    ```markdown
@@ -225,7 +225,7 @@ Execution steps:
 
 ## Session Log Format
 
-Session logs are stored at `.specledger/sessions/<branch>-session.md`:
+Session logs are stored at `FEATURE_DIR/sessions/<spec>-checkpoint.md`:
 
 ```markdown
 # Session Log: <branch-name>

--- a/pkg/embedded/templates/specledger/commands/specledger.clarify.md
+++ b/pkg/embedded/templates/specledger/commands/specledger.clarify.md
@@ -174,7 +174,7 @@ Execution steps:
 Behavior rules:
 
 - If no meaningful ambiguities found (or all potential questions would be low-impact), respond: "No critical ambiguities detected worth formal clarification." and suggest proceeding.
-- If spec file missing, instruct user to run `/specledger.specledger` first (do not create a new spec here).
+- If spec file missing, instruct user to run `/specledger.specify` first (do not create a new spec here).
 - Never exceed 10 total asked questions (clarification retries for a single question do not count as new questions).
 - Avoid speculative tech stack questions unless the absence blocks functional clarity.
 - Respect user early termination signals ("stop", "done", "proceed").

--- a/pkg/embedded/templates/specledger/commands/specledger.constitution.md
+++ b/pkg/embedded/templates/specledger/commands/specledger.constitution.md
@@ -2,7 +2,7 @@
 description: Create or update the project constitution from interactive or provided principle inputs, ensuring all dependent templates stay in sync.
 handoffs: 
   - label: Build Specification
-    agent: specledger.specledger
+    agent: specledger.specify
     prompt: Implement the feature specification based on the updated constitution. I want to build...
 ---
 

--- a/pkg/embedded/templates/specledger/commands/specledger.implement.md
+++ b/pkg/embedded/templates/specledger/commands/specledger.implement.md
@@ -68,13 +68,30 @@ Execute the implementation plan by processing all tasks in tasks.md. This comman
      * **STOP** and use AskUserQuestion to ask: "Some checklists are incomplete. Do you want to proceed with implementation anyway? (yes/no)"
      * Wait for user response before continuing
      * If user says "no" or "wait" or "stop", halt execution
-     * If user says "yes" or "proceed" or "continue", proceed to step 4
+     * If user says "yes" or "proceed" or "continue", proceed to step 5
 
     - **If all checklists are complete**:
       * Display the table showing all checklists passed
       * Automatically proceed to step 5
 
-5. Load and analyze the implementation context:
+5. **Pre-flight review check** (verify review detection):
+
+   Check if `FEATURE_DIR/reviews/` contains any review files (written by `/specledger.verify`).
+
+   **If a review file exists**: Proceed silently — verification was already completed.
+
+   **If no review file exists**: Use AskUserQuestion to ask:
+
+   > **No Verify Review Found**
+   >
+   > No verification review was found in `FEATURE_DIR/reviews/`. It is **strongly recommended** to run `/specledger.verify` at least once before implementing — this catches spec/plan/task consistency issues that are much harder to fix during implementation.
+   >
+   > **Would you like to run `/specledger.verify` now, or proceed without a review?**
+
+   If the user chooses to verify, pause implementation and run `/specledger.verify`. Resume implementation after verification completes.
+   If the user chooses to proceed, continue — but note in the execution log that verification was skipped.
+
+6. Load and analyze the implementation context:
    - **REQUIRED**: Read tasks.md for the complete task list and execution plan
    - **REQUIRED**: Read plan.md for tech stack, architecture, and file structure
    - **IF EXISTS**: Read data-model.md for entities and relationships
@@ -82,7 +99,7 @@ Execute the implementation plan by processing all tasks in tasks.md. This comman
    - **IF EXISTS**: Read research.md for technical decisions and constraints
    - **IF EXISTS**: Read quickstart.md for integration scenarios
 
-6. **Project Setup Verification**:
+7. **Project Setup Verification**:
    - **REQUIRED**: Create/verify ignore files based on actual project setup:
 
    **Detection & Creation Logic**:
@@ -116,26 +133,35 @@ Execute the implementation plan by processing all tasks in tasks.md. This comman
    - **Prettier**: `node_modules/`, `dist/`, `build/`, `coverage/`, `package-lock.json`, `yarn.lock`, `pnpm-lock.yaml`
     - **Terraform**: `.terraform/`, `*.tfstate*`, `*.tfvars`, `.terraform.lock.hcl`
 
-7. Read tasks.md structure and extract:
+8. Read tasks.md structure and extract:
    - **Task phases**: Setup, Tests, Core, Integration, Polish
    - **Task dependencies**: Sequential vs parallel execution rules
    - **Task details**: ID, description, file paths, design + acceptance criteria
    - **Task comments**: Important notes and modifications to original plan
    - **Execution flow**: Order and dependency requirements
 
-8. Execute implementation following the task plan:
+9. Execute implementation following the task plan:
    - **Phase-by-phase execution**: Complete each phase before moving to the next
    - **Respect dependencies**: Run sequential tasks in order, parallel tasks [P] can run together
    - **Follow TDD approach**: Execute test tasks before their corresponding implementation tasks
    - **File-based coordination**: Tasks affecting the same files must run sequentially
    - **Validation checkpoints**: Verify each phase completion before proceeding
+   - **Phase checkpoint suggestion**: After completing all tasks in a phase, check if this phase has already been covered by a previous checkpoint (look for existing checkpoint files in `FEATURE_DIR/sessions/`). If not already checkpointed, use AskUserQuestion to suggest a scoped checkpoint:
+
+     > **Phase "[phase name]" Complete**
+     >
+     > All tasks in this phase are closed. You can run a scoped `/specledger.checkpoint` to verify issues and DoD for this phase before continuing.
+     >
+     > **Run scoped checkpoint for this phase, or continue to the next phase?**
+
+     If the user accepts, run `/specledger.checkpoint "Verify phase:[phase-name] issues only — phase completed this session"`. If the user skips, proceed to the next phase.
    - **Read issue fields before implementation**:
      - Use `sl issue show <id>` to retrieve the issue's details
      - Read the `design` field for technical approach and file references
       - Read the `acceptance_criteria` field for requirements and success criteria
       - Use these fields to guide implementation decisions
 
-9. Implementation execution rules:
+10. Implementation execution rules:
    - **Setup first**: Initialize project structure, dependencies, configuration
    - **Tests before code**: If you need to write tests for contracts, entities, and integration scenarios
    - **Core development**: Implement models, services, CLI commands, endpoints
@@ -145,7 +171,7 @@ Execute the implementation plan by processing all tasks in tasks.md. This comman
    - **Check off DoD items progressively**: As subtasks complete, use `sl issue update <id> --check-dod "Item text"` to mark relevant DoD items as verified
     - **Only close after all DoD items checked**: Ensure all Definition of Done items are marked complete before closing an issue
 
-10. Progress tracking and error handling:
+11. Progress tracking and error handling:
    - Find ready tasks using: `sl issue ready`
    - If no ready tasks, display blocking issues and offer options
    - Update issue status with: `sl issue update <id> --status in_progress`
@@ -156,7 +182,7 @@ Execute the implementation plan by processing all tasks in tasks.md. This comman
    - Suggest next steps if implementation cannot proceed
     - **IMPORTANT** For completed tasks, make sure to close the issue: `sl issue close <id> --reason "Completed"`
 
-10a. **Definition of Done Verification** (before closing issues):
+11a. **Definition of Done Verification** (before closing issues):
 
    Before closing any issue, verify its Definition of Done items:
 
@@ -197,12 +223,29 @@ Execute the implementation plan by processing all tasks in tasks.md. This comman
        Proceed with closing? (--force required)
        ```
 
-11. Completion validation:
+12. Completion validation:
    - Verify all required tasks are completed
    - Check that implemented features match the original specification
    - Validate that tests pass and coverage meets requirements
    - Confirm the implementation follows the technical plan
    - Report final status with summary of completed work
+
+13. **Post-Implementation Checkpoint** (strongly recommended):
+
+   After all tasks are complete and the completion summary is presented, use AskUserQuestion to ask:
+
+   > **All Tasks Complete — Checkpoint Strongly Recommended**
+   >
+   > Implementation is finished. Before merging or considering this feature done, it is **strongly recommended** to run `/specledger.checkpoint` for a critical divergence review. The checkpoint will:
+   > - Compare implementation against spec, plan, and task artifacts
+   > - Flag any force-closed issues with unchecked Definition of Done items
+   > - Surface coverage gaps and plan drift
+   > - Offer an independent adversarial review agent for a fresh-eyes code review
+   >
+   > **Would you like to run the checkpoint now?**
+
+   If the user accepts, invoke `/specledger.checkpoint`.
+   If the user declines, note in the completion summary that the post-implementation checkpoint was skipped.
 
 ## Issue Tracking Commands
 
@@ -221,7 +264,7 @@ Use the built-in `sl issue` commands for issue management:
 
 ## Definition of Done
 
-Before closing an issue, verify the Definition of Done criteria using the verification process in step 9a:
+Before closing an issue, verify the Definition of Done criteria using the verification process in step 11a:
 
 ### Verification Process
 

--- a/pkg/embedded/templates/specledger/commands/specledger.implement.md
+++ b/pkg/embedded/templates/specledger/commands/specledger.implement.md
@@ -146,7 +146,7 @@ Execute the implementation plan by processing all tasks in tasks.md. This comman
    - **Follow TDD approach**: Execute test tasks before their corresponding implementation tasks
    - **File-based coordination**: Tasks affecting the same files must run sequentially
    - **Validation checkpoints**: Verify each phase completion before proceeding
-   - **Phase checkpoint suggestion**: After completing all tasks in a phase, check if this phase has already been covered by a previous checkpoint (look for existing checkpoint files in `FEATURE_DIR/sessions/`). If not already checkpointed, use AskUserQuestion to suggest a scoped checkpoint:
+   - **Phase checkpoint suggestion**: After completing all tasks in a phase, check if this specific phase has already been checkpointed by looking for `FEATURE_DIR/sessions/<branch-name>-checkpoint-<phase-name>.md`. If that file does not exist, use AskUserQuestion to suggest a scoped checkpoint:
 
      > **Phase "[phase name]" Complete**
      >

--- a/pkg/embedded/templates/specledger/commands/specledger.onboard.md
+++ b/pkg/embedded/templates/specledger/commands/specledger.onboard.md
@@ -32,6 +32,16 @@ Check if a populated project constitution exists at `.specledger/memory/constitu
   - **Important**: The constitution captures high-level software design principles (e.g., YAGNI, test-first, simplicity, contract-driven design) — NOT technology selections discovered during the audit. The audit provides codebase familiarity; principles come from how the team wants to approach software design.
 - Wait for the user to review and approve the constitution before proceeding.
 
+**Commit Suggestion**: After the constitution is created or confirmed, use AskUserQuestion to suggest:
+
+> **Constitution Ready — Commit Setup?**
+>
+> Your project constitution is in place. It's a good idea to commit this setup before starting feature work.
+>
+> **Would you like to commit the constitution and setup files now?**
+
+If the user accepts, commit the constitution and any setup files. If skipped, proceed to Step 2.
+
 ### Step 2: Welcome & Orientation
 
 Present a brief welcome message:
@@ -44,7 +54,9 @@ Present a brief welcome message:
 > 3. **Plan** - Design the implementation approach
 > 4. **Tasks** - Generate actionable, ordered tasks
 > 5. **Review** - You review tasks before any code is written
-> 6. **Implement** - Execute the tasks
+> 6. **Verify** - Cross-check spec/plan/task consistency (recommended)
+> 7. **Implement** - Execute the tasks
+> 8. **Checkpoint** - Review implementation against plan (recommended)
 >
 > Let's start by describing your first feature!
 
@@ -59,8 +71,9 @@ Before we begin, here's a quick reference of the available SpecLedger commands:
 | `/specledger.clarify` | Resolve ambiguities and answer spec questions |
 | `/specledger.plan` | Generate technical implementation plan |
 | `/specledger.tasks` | Create ordered, dependency-linked task list |
-| `/specledger.implement` | Execute implementation tasks in order |
 | `/specledger.verify` | Cross-artifact consistency and quality check |
+| `/specledger.implement` | Execute implementation tasks in order |
+| `/specledger.checkpoint` | Divergence review during/after implementation |
 
 **Utility Commands:**
 | Command | Description |
@@ -146,15 +159,53 @@ Present the generated tasks to the user and use AskUserQuestion to ask:
 >
 > **Would you like to proceed with implementation, or would you like to modify any tasks first?**
 
+### Step 8.5: Verification (Recommended)
+
+After the user approves the tasks, recommend running verification before implementation.
+
+Use AskUserQuestion to ask:
+
+> **Pre-Implementation Verification**
+>
+> Before we start coding, it's strongly recommended to run `/specledger.verify` to check that your spec, plan, and tasks are consistent and complete. At least one verify review should exist before implementation begins.
+>
+> **Would you like to run verification now, or skip and go straight to implementation?**
+
+If the user chooses to verify:
+- Run `/specledger.verify` to perform cross-artifact consistency analysis.
+- If CRITICAL issues are found, recommend resolving them before proceeding.
+- After verification completes (or if only LOW/MEDIUM issues), ask if they want to proceed to implementation.
+
+If the user skips, proceed directly to Step 9.
+
 ### Step 9: Implementation
 
 Only after the user has reviewed and approved the tasks:
 
 Run `/specledger.implement` to begin executing the tasks in order.
 
+### Step 10: Post-Implementation Checkpoint (Recommended)
+
+After implementation completes, recommend a checkpoint review.
+
+Use AskUserQuestion to ask:
+
+> **Implementation Complete — Checkpoint Recommended**
+>
+> All tasks have been implemented. Before wrapping up, it's strongly recommended to run `/specledger.checkpoint` for a divergence review. This will compare your implementation against the plan, flag any gaps, and offer an adversarial code review.
+>
+> **Would you like to run a checkpoint now?**
+
+If the user accepts:
+- Run `/specledger.checkpoint` to perform the divergence review.
+- If the checkpoint offers an adversarial review agent, let the user decide whether to run it.
+
+If the user declines, summarize what was completed and note the checkpoint was skipped.
+
 ## Important Notes
 
 - **Never skip the review pause** in Step 8. The user must always approve tasks before implementation begins.
+- **Verify and checkpoint are optional but recommended.** If a user skips them during onboarding, note that they can always run `/specledger.verify` or `/specledger.checkpoint` independently later.
 - If the user wants to modify tasks, help them update the specledger issues before proceeding.
 - If the user wants to stop at any point, respect that and summarize what was completed.
 - Each step builds on the previous one - don't skip steps unless the user explicitly asks.

--- a/pkg/embedded/templates/specledger/commands/specledger.specify.md
+++ b/pkg/embedded/templates/specledger/commands/specledger.specify.md
@@ -30,7 +30,7 @@ Create feature specifications from natural language descriptions. This is the st
 
 ## Outline
 
-The text the user typed after `/specledger.specledger` in the triggering message **is** the feature description. Assume you always have it available in this conversation even if `$ARGUMENTS` appears literally below. Do not ask the user to repeat it unless they provided an empty command.
+The text the user typed after `/specledger.specify` in the triggering message **is** the feature description. Assume you always have it available in this conversation even if `$ARGUMENTS` appears literally below. Do not ask the user to repeat it unless they provided an empty command.
 
 Given that feature description, do this:
 

--- a/pkg/embedded/templates/specledger/commands/specledger.tasks.md
+++ b/pkg/embedded/templates/specledger/commands/specledger.tasks.md
@@ -1,10 +1,9 @@
 ---
 description: Generate an actionable, dependency-ordered tasks.md for the feature based on available design artifacts.
 handoffs:
-  - label: Analyze For Consistency
-    agent: specledger.analyze
-    prompt: Run a project analysis for consistency
-    send: true
+  - label: Verify For Consistency
+    agent: specledger.verify
+    prompt: Run a cross-artifact consistency and quality verification
   - label: Implement Project
     agent: specledger.implement
     prompt: Start the implementation in phases
@@ -128,6 +127,22 @@ Generate actionable, dependency-ordered tasks from the implementation plan. Task
    - Parallel opportunities identified
    - Independent test criteria for each story
    - Suggested MVP (usually US1 or first P1 story)
+
+7. **Pre-Implementation Verify Check** (strongly recommended):
+
+   After presenting the report, check if `FEATURE_DIR/reviews/` contains any review files.
+
+   **If a review file exists**: Skip this prompt — verification was already completed. Proceed to implementation handoff.
+
+   **If no review file exists**: Use AskUserQuestion to ask:
+
+   > **Verification Strongly Recommended**
+   >
+   > At least one verify review should exist before implementation begins. Running `/specledger.verify` will cross-check your spec, plan, and tasks for consistency gaps, coverage issues, and ambiguities — catching problems now is far cheaper than finding them during implementation.
+   >
+   > **Would you like to run `/specledger.verify` now? (Strongly recommended)**
+
+   If the user accepts, the handoff to `specledger.verify` handles execution. If the user skips, proceed to the `specledger.implement` handoff — but note in the summary that verification was skipped.
 
 Context for task generation: $ARGUMENTS
 

--- a/pkg/embedded/templates/specledger/commands/specledger.verify.md
+++ b/pkg/embedded/templates/specledger/commands/specledger.verify.md
@@ -170,11 +170,36 @@ At end of report, output a concise Next Actions block:
 
 - If CRITICAL issues exist: Recommend resolving before `/specledger.implement`
 - If only LOW/MEDIUM: User may proceed, but provide improvement suggestions
-- Provide explicit command suggestions: e.g., "Run /specledger.specledger with refinement", "Run /specledger.plan to adjust architecture", "Manually edit tasks.md to add coverage for 'performance-metrics'"
+- Provide explicit command suggestions: e.g., "Run /specledger.specify with refinement", "Run /specledger.plan to adjust architecture", "Manually edit tasks.md to add coverage for 'performance-metrics'"
 
 ### 8. Offer Remediation
 
 Use the AskUserQuestion tool to ask: "Would you like me to suggest concrete remediation edits for the top N issues?" (Do NOT apply them automatically.)
+
+### 9. Persist Review Report (Recommended)
+
+After the analysis is complete and any remediation discussion is finished, offer to save the review.
+
+Use AskUserQuestion to ask: **"Would you like to save this review to `FEATURE_DIR/reviews/<spec-number>-review.md`?"** (Recommended — at least one review should exist before implementation begins.)
+
+**If the user accepts:**
+1. Create the `FEATURE_DIR/reviews/` directory if it doesn't exist
+2. Write the full analysis report (findings table, coverage summary, constitution alignment, unmapped tasks, metrics, and next actions) to `FEATURE_DIR/reviews/<spec-number>-review.md` (e.g., `006-review.md`)
+3. Include a YAML frontmatter header with date and summary metrics:
+   ```yaml
+   ---
+   date: YYYY-MM-DD
+   total_requirements: N
+   total_tasks: N
+   coverage_pct: N%
+   critical_issues: N
+   ---
+   ```
+4. Confirm the file was written and its path
+
+**If the user declines:** Note that no review file was persisted. The `/specledger.tasks` and `/specledger.implement` skills check for review files and will prompt again before implementation.
+
+**IMPORTANT**: The analysis itself (steps 1-8) remains **strictly read-only**. This file write is a separate, explicit opt-in step that happens only after analysis is complete.
 
 ## Operating Principles
 
@@ -187,7 +212,7 @@ Use the AskUserQuestion tool to ask: "Would you like me to suggest concrete reme
 
 ### Analysis Guidelines
 
-- **NEVER modify files** (this is read-only analysis)
+- **NEVER modify files during analysis** (steps 1-8 are strictly read-only; step 9 is an explicit opt-in write)
 - **NEVER hallucinate missing sections** (if absent, report them accurately)
 - **Prioritize constitution violations** (these are always CRITICAL)
 - **Use examples over exhaustive rules** (cite specific instances, not generic patterns)


### PR DESCRIPTION
## Summary
- Fix broken `specledger.analyze` handoff in tasks skill (spec-kit analyze was renamed to verify — now correctly references `specledger.verify`)
- Add verify and checkpoint prompts throughout the workflow: tasks completion strongly recommends verify before implementation, implement adds pre-flight review check + mid-phase and post-implementation checkpoint suggestions, onboard includes both as guided steps
- Enable verify to persist review reports to `FEATURE_DIR/reviews/` (opt-in after read-only analysis) and move checkpoint output to `FEATURE_DIR/sessions/` to co-locate with feature artifacts
- Fix stale `specledger.analyze` references in GUIDELINES.md and a `/specledger.specledger` typo in verify.md

## Test plan
- [x] `make test` — all tests pass
- [x] `make lint` — 0 issues
- [x] All 5 `.agents/commands/` files verified identical to `pkg/embedded/templates/` counterparts
- [x] Adversarial review agent confirmed all 12 planned changes implemented correctly
- [ ] Manual walkthrough: run `/specledger.onboard` or `/specledger.tasks` to confirm new AskUserQuestion prompts appear at correct points

🤖 Generated with [Claude Code](https://claude.com/claude-code)