### PR TITLE
fix(skills): download full skill directory, not just SKILL.md

### DIFF
--- a/pkg/cli/commands/skill.go
+++ b/pkg/cli/commands/skill.go
@@ -215,6 +215,7 @@ func runSkillAdd(_ *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
+	defer source.Cleanup()
 
 	projectRoot, err := metadata.FindProjectRoot()
 	if err != nil {
@@ -321,18 +322,13 @@ func runSkillAdd(_ *cobra.Command, args []string) error {
 	var results []installResult
 
 	for _, s := range toInstall {
-		// Use the discovered repo path if available, fallback to conventional layout
-		fetchPath := s.RepoPath
-		if fetchPath == "" {
-			fetchPath = fmt.Sprintf("skills/%s/SKILL.md", s.Name)
-		}
-		content, err := client.FetchSkillContent(source.Owner, source.Repo, source.Ref, fetchPath)
+		files, err := skills.FetchSkillFiles(client, source, &s)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Error: failed to fetch %s: %v\n", s.Name, err)
 			continue
 		}
 
-		if err := skills.InstallSkill(s.Name, content, agentPaths, lockPath, source); err != nil {
+		if err := skills.InstallSkill(s.Name, files, agentPaths, lockPath, source); err != nil {
 			fmt.Fprintf(os.Stderr, "Error: failed to install %s: %v\n", s.Name, err)
 			continue
 		}

--- a/pkg/cli/skills/client.go
+++ b/pkg/cli/skills/client.go
@@ -188,8 +188,9 @@ type GitHubTreeEntry struct {
 }
 
 type githubTreeResponse struct {
-	SHA  string            `json:"sha"`
-	Tree []GitHubTreeEntry `json:"tree"`
+	SHA       string            `json:"sha"`
+	Tree      []GitHubTreeEntry `json:"tree"`
+	Truncated bool              `json:"truncated"`
 }
 
 // defaultRefFallbacks is the ordered list of refs to try when no explicit ref is given.
@@ -198,8 +199,8 @@ var defaultRefFallbacks = []string{"HEAD", "main", "master"}
 
 // FetchRepoTree fetches the full recursive tree for a repository.
 // When ref is empty, it tries HEAD, main, master in order (matching skills.sh behavior).
-// Returns the tree entries and the ref that succeeded.
-func (c *Client) FetchRepoTree(owner, repo, ref string) ([]GitHubTreeEntry, string, error) {
+// Returns the tree entries, the ref that succeeded, and whether the response was truncated.
+func (c *Client) FetchRepoTree(owner, repo, ref string) ([]GitHubTreeEntry, string, bool, error) {
 	refs := []string{ref}
 	if ref == "" {
 		refs = defaultRefFallbacks
@@ -207,27 +208,27 @@ func (c *Client) FetchRepoTree(owner, repo, ref string) ([]GitHubTreeEntry, stri
 
 	var lastErr error
 	for _, r := range refs {
-		tree, err := c.fetchRepoTreeOnce(owner, repo, r)
+		tree, truncated, err := c.fetchRepoTreeOnce(owner, repo, r)
 		if err == nil {
-			return tree, r, nil
+			return tree, r, truncated, nil
 		}
 		lastErr = err
 	}
 
 	// When auto-resolving, clarify that the repo may exist but we couldn't find the branch
 	if ref == "" {
-		return nil, "", fmt.Errorf("could not resolve default branch for %s/%s (tried HEAD, main, master)\n→ Verify the repository is public and accessible", owner, repo)
+		return nil, "", false, fmt.Errorf("could not resolve default branch for %s/%s (tried HEAD, main, master)\n→ Verify the repository is public and accessible", owner, repo)
 	}
-	return nil, "", lastErr
+	return nil, "", false, lastErr
 }
 
-func (c *Client) fetchRepoTreeOnce(owner, repo, ref string) ([]GitHubTreeEntry, error) {
+func (c *Client) fetchRepoTreeOnce(owner, repo, ref string) ([]GitHubTreeEntry, bool, error) {
 	reqURL := fmt.Sprintf("%s/repos/%s/%s/git/trees/%s?recursive=1",
 		c.GitHubURL, owner, repo, url.PathEscape(ref))
 
 	req, err := http.NewRequest(http.MethodGet, reqURL, nil)
 	if err != nil {
-		return nil, fmt.Errorf("GitHub Trees API request failed: %w", err)
+		return nil, false, fmt.Errorf("GitHub Trees API request failed: %w", err)
 	}
 	req.Header.Set("Accept", "application/json")
 
@@ -238,23 +239,23 @@ func (c *Client) fetchRepoTreeOnce(owner, repo, ref string) ([]GitHubTreeEntry, 
 
 	resp, err := c.HTTPClient.Do(req)
 	if err != nil {
-		return nil, fmt.Errorf("GitHub API unreachable\n→ Check your internet connection and try again")
+		return nil, false, fmt.Errorf("GitHub API unreachable\n→ Check your internet connection and try again")
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode == http.StatusNotFound {
-		return nil, fmt.Errorf("repository %q not found (404)\n→ Verify the repository exists and is public.\n→ For private repos, set GITHUB_TOKEN.", owner+"/"+repo)
+		return nil, false, fmt.Errorf("repository %q not found (404)\n→ Verify the repository exists and is public.\n→ For private repos, set GITHUB_TOKEN.", owner+"/"+repo)
 	}
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("GitHub Trees API failed (%d)\n→ Try again later. If rate-limited, set GITHUB_TOKEN.", resp.StatusCode)
+		return nil, false, fmt.Errorf("GitHub Trees API failed (%d)\n→ Try again later. If rate-limited, set GITHUB_TOKEN.", resp.StatusCode)
 	}
 
 	var result githubTreeResponse
 	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
-		return nil, fmt.Errorf("GitHub Trees API: invalid response: %w", err)
+		return nil, false, fmt.Errorf("GitHub Trees API: invalid response: %w", err)
 	}
 
-	return result.Tree, nil
+	return result.Tree, result.Truncated, nil
 }
 
 func envOrDefault(key, def string) string {

--- a/pkg/cli/skills/client.go
+++ b/pkg/cli/skills/client.go
@@ -147,7 +147,7 @@ func (c *Client) FetchAudit(source string, slugs []string) (map[string]*SkillAud
 	return results, nil
 }
 
-// FetchSkillContent fetches the raw SKILL.md content from GitHub.
+// FetchSkillContent fetches raw file content from GitHub (any path under a skill directory).
 func (c *Client) FetchSkillContent(owner, repo, ref, skillPath string) ([]byte, error) {
 	reqURL := fmt.Sprintf("%s/%s/%s/%s/%s",
 		c.RawGHURL, owner, repo, url.PathEscape(ref), skillPath)

--- a/pkg/cli/skills/client_test.go
+++ b/pkg/cli/skills/client_test.go
@@ -172,7 +172,7 @@ func TestClientFetchRepoTree(t *testing.T) {
 	defer srv.Close()
 
 	c := &Client{GitHubURL: srv.URL, HTTPClient: srv.Client()}
-	tree, resolvedRef, err := c.FetchRepoTree("vercel-labs", "agent-skills", "main")
+	tree, resolvedRef, _, err := c.FetchRepoTree("vercel-labs", "agent-skills", "main")
 	if err != nil {
 		t.Fatalf("FetchRepoTree: %v", err)
 	}
@@ -191,7 +191,7 @@ func TestClientFetchRepoTree_NotFound(t *testing.T) {
 	defer srv.Close()
 
 	c := &Client{GitHubURL: srv.URL, HTTPClient: srv.Client()}
-	_, _, err := c.FetchRepoTree("nonexistent", "repo", "main")
+	_, _, _, err := c.FetchRepoTree("nonexistent", "repo", "main")
 	if err == nil {
 		t.Fatal("expected error for 404")
 	}
@@ -260,7 +260,7 @@ func TestFetchRepoTree_RefFallback(t *testing.T) {
 			defer srv.Close()
 
 			c := &Client{GitHubURL: srv.URL, HTTPClient: srv.Client()}
-			tree, resolvedRef, err := c.FetchRepoTree("org", "repo", tt.inputRef)
+			tree, resolvedRef, _, err := c.FetchRepoTree("org", "repo", tt.inputRef)
 
 			if tt.wantErr != "" {
 				if err == nil {
@@ -526,7 +526,7 @@ func TestFetchRepoTree_AuthHeader(t *testing.T) {
 	defer srv.Close()
 
 	c := &Client{GitHubURL: srv.URL, HTTPClient: srv.Client()}
-	_, _, err := c.FetchRepoTree("owner", "repo", "main")
+	_, _, _, err := c.FetchRepoTree("owner", "repo", "main")
 	if err != nil {
 		t.Fatalf("FetchRepoTree: %v", err)
 	}
@@ -541,7 +541,7 @@ func TestFetchRepoTree_JSONDecodeError(t *testing.T) {
 	defer srv.Close()
 
 	c := &Client{GitHubURL: srv.URL, HTTPClient: srv.Client()}
-	_, _, err := c.FetchRepoTree("owner", "repo", "main")
+	_, _, _, err := c.FetchRepoTree("owner", "repo", "main")
 	if err == nil {
 		t.Fatal("expected error for invalid JSON")
 	}
@@ -563,5 +563,79 @@ func TestFetchSkillContent_Non200Non404(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "failed to fetch") {
 		t.Errorf("error = %q, want containing 'failed to fetch'", err.Error())
+	}
+}
+
+func TestFetchRepoTree_TruncatedFallback(t *testing.T) {
+	// When the Trees API returns truncated: true, discoverViaGitHub should
+	// return errTreeTruncated so DiscoverSkills falls through to clone.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		resp := githubTreeResponse{
+			SHA:       "abc123",
+			Tree:      []GitHubTreeEntry{{Path: "skills/partial/SKILL.md", Type: "blob", Mode: "100644"}},
+			Truncated: true,
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer srv.Close()
+
+	c := &Client{GitHubURL: srv.URL, HTTPClient: srv.Client()}
+	_, _, truncated, err := c.FetchRepoTree("owner", "repo", "main")
+	if err != nil {
+		t.Fatalf("FetchRepoTree should not error: %v", err)
+	}
+	if !truncated {
+		t.Fatal("expected truncated = true")
+	}
+
+	// Now verify discoverViaGitHub returns errTreeTruncated
+	// We need a RawGHURL too (for SKILL.md fetching, which won't be reached)
+	c.RawGHURL = srv.URL
+	source := &SkillSource{Owner: "owner", Repo: "repo", Ref: "main", Type: SourceTypeGitHub}
+	_, err = discoverViaGitHub(c, source)
+	if err == nil {
+		t.Fatal("expected errTreeTruncated")
+	}
+	if err != errTreeTruncated {
+		t.Errorf("error = %v, want errTreeTruncated", err)
+	}
+}
+
+func TestFetchSkillContent_429Retry(t *testing.T) {
+	// Simulate a 429 on first request, then success on retry.
+	calls := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		if r.Method == "HEAD" {
+			// parseRetryWait does a HEAD to check rate-limit status
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		if calls <= 2 {
+			// First GET returns 429
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		// Subsequent GET succeeds
+		_, _ = w.Write([]byte("---\nname: test\ndescription: Test\n---\n"))
+	}))
+	defer srv.Close()
+
+	c := &Client{RawGHURL: srv.URL, HTTPClient: srv.Client()}
+	source := &SkillSource{Owner: "owner", Repo: "repo", Ref: "main", Type: SourceTypeGitHub}
+	skill := &SkillMetadata{
+		Name:     "test",
+		RepoPath: "skills/test/SKILL.md",
+		Files:    []string{"skills/test/SKILL.md"},
+	}
+
+	files, err := FetchSkillFiles(c, source, skill)
+	if err != nil {
+		t.Fatalf("FetchSkillFiles should succeed after retry: %v", err)
+	}
+	if _, ok := files["SKILL.md"]; !ok {
+		t.Error("expected SKILL.md in result")
 	}
 }

--- a/pkg/cli/skills/discover.go
+++ b/pkg/cli/skills/discover.go
@@ -1,10 +1,12 @@
 package skills
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"sort"
 	"strings"
 
 	"gopkg.in/yaml.v3"
@@ -12,13 +14,19 @@ import (
 
 // SkillMetadata is parsed from SKILL.md YAML frontmatter.
 type SkillMetadata struct {
-	Name        string `yaml:"name" json:"name"`
-	Description string `yaml:"description" json:"description"`
-	Slug        string `yaml:"-" json:"slug,omitempty"`
-	Source      string `yaml:"-" json:"source,omitempty"`
-	RepoPath    string `yaml:"-" json:"-"` // path to SKILL.md within the repo (set during discovery)
-	Internal    bool   `yaml:"internal,omitempty" json:"-"`
+	Name        string   `yaml:"name" json:"name"`
+	Description string   `yaml:"description" json:"description"`
+	Slug        string   `yaml:"-" json:"slug,omitempty"`
+	Source      string   `yaml:"-" json:"source,omitempty"`
+	RepoPath    string   `yaml:"-" json:"-"` // path to SKILL.md within the repo (set during discovery)
+	Files       []string `yaml:"-" json:"-"` // all repo-relative file paths under the skill directory
+	Internal    bool     `yaml:"internal,omitempty" json:"-"`
 }
+
+// errTreeTruncated is returned by discoverViaGitHub when the Trees API response
+// is truncated (>100k entries or >7 MB). DiscoverSkills uses this to auto-fallback
+// to the clone path.
+var errTreeTruncated = errors.New("GitHub tree response truncated")
 
 // DiscoverSkills enumerates available skills in a repository.
 // For GitHub sources, uses the Trees API (fast path).
@@ -29,7 +37,10 @@ func DiscoverSkills(client *Client, source *SkillSource) ([]SkillMetadata, error
 		if err == nil {
 			return skills, nil
 		}
-		// Auto-retry via git clone on GitHub API failure
+		// Auto-retry via git clone on GitHub API failure (including truncation)
+		if errors.Is(err, errTreeTruncated) {
+			fmt.Fprintf(os.Stderr, "→ tree response truncated, falling back to clone\n")
+		}
 		cloneURL := fmt.Sprintf("https://github.com/%s/%s.git", source.Owner, source.Repo)
 		return discoverViaClone(cloneURL, source)
 	}
@@ -39,16 +50,20 @@ func DiscoverSkills(client *Client, source *SkillSource) ([]SkillMetadata, error
 }
 
 func discoverViaGitHub(client *Client, source *SkillSource) ([]SkillMetadata, error) {
-	tree, resolvedRef, err := client.FetchRepoTree(source.Owner, source.Repo, source.Ref)
+	tree, resolvedRef, truncated, err := client.FetchRepoTree(source.Owner, source.Repo, source.Ref)
 	if err != nil {
 		return nil, err
+	}
+
+	if truncated {
+		return nil, errTreeTruncated
 	}
 
 	// Propagate the resolved ref so install fetches use the correct branch
 	source.Ref = resolvedRef
 
-	// Find SKILL.md files in the tree
-	var skillPaths []string
+	// Build set of skill directories (each containing a SKILL.md)
+	skillDirs := make(map[string]string) // dir → full SKILL.md path
 	for _, entry := range tree {
 		if entry.Type != "blob" {
 			continue
@@ -56,16 +71,52 @@ func discoverViaGitHub(client *Client, source *SkillSource) ([]SkillMetadata, er
 		if !strings.HasSuffix(entry.Path, "/SKILL.md") {
 			continue
 		}
-		skillPaths = append(skillPaths, entry.Path)
+		dir := strings.TrimSuffix(entry.Path, "/SKILL.md")
+		skillDirs[dir] = entry.Path
 	}
 
-	if len(skillPaths) == 0 {
+	if len(skillDirs) == 0 {
 		return nil, fmt.Errorf("no skills found in %s/%s\n→ The repository may not contain SKILL.md files", source.Owner, source.Repo)
 	}
 
+	// For each tree entry, find the deepest enclosing skill dir.
+	// This avoids assigning a file to a parent skill when it belongs to a nested skill.
+	findOwningSkillDir := func(filePath string) string {
+		best := ""
+		for dir := range skillDirs {
+			prefix := dir + "/"
+			if strings.HasPrefix(filePath, prefix) && len(dir) > len(best) {
+				best = dir
+			}
+		}
+		return best
+	}
+
+	// Build file lists per skill dir, skipping symlinks and submodules
+	skillFiles := make(map[string][]string) // skill dir → list of repo-relative paths
+	for _, entry := range tree {
+		if entry.Type != "blob" {
+			continue
+		}
+		// Skip symlinks (120000) and submodules (160000)
+		if entry.Mode == "120000" || entry.Mode == "160000" {
+			continue
+		}
+		owningDir := findOwningSkillDir(entry.Path)
+		if owningDir == "" {
+			continue
+		}
+		skillFiles[owningDir] = append(skillFiles[owningDir], entry.Path)
+	}
+
+	// Sort file lists for deterministic order (VCR cassettes depend on this)
+	for dir := range skillFiles {
+		sort.Strings(skillFiles[dir])
+	}
+
 	var skills []SkillMetadata
-	for _, path := range skillPaths {
-		content, err := client.FetchSkillContent(source.Owner, source.Repo, source.Ref, path)
+	for dir, skillMdPath := range skillDirs {
+		content, err := client.FetchSkillContent(source.Owner, source.Repo, source.Ref, skillMdPath)
 		if err != nil {
 			continue // skip individual fetch failures
 		}
@@ -77,7 +128,8 @@ func discoverViaGitHub(client *Client, source *SkillSource) ([]SkillMetadata, er
 
 		meta.Source = source.SourceString()
 		meta.Slug = source.SourceString() + "/" + meta.Name
-		meta.RepoPath = path // preserve discovered path for install fetch
+		meta.RepoPath = skillMdPath // preserve discovered path for install fetch
+		meta.Files = skillFiles[dir]
 
 		// Apply skill filter if specified
 		if source.SkillFilter != "" && meta.Name != source.SkillFilter {
@@ -104,7 +156,9 @@ func discoverViaClone(cloneURL string, source *SkillSource) ([]SkillMetadata, er
 	if err != nil {
 		return nil, fmt.Errorf("failed to create temp directory: %w", err)
 	}
-	defer os.RemoveAll(tmpDir)
+	// Store on source so FetchSkillFiles can read from the clone.
+	// Caller is responsible for calling source.Cleanup().
+	source.cloneDir = tmpDir
 
 	// git clone --depth 1; omit --branch when ref is empty to use repo's default
 	args := []string{"clone", "--depth", "1"}
@@ -119,10 +173,15 @@ func discoverViaClone(cloneURL string, source *SkillSource) ([]SkillMetadata, er
 		return nil, fmt.Errorf("sl skill add failed: could not clone %q\n→ Verify the repository exists and is accessible", cloneURL)
 	}
 
-	// Scan for SKILL.md files
-	var skills []SkillMetadata
-	err = filepath.Walk(tmpDir, func(path string, info os.FileInfo, err error) error {
-		if err != nil {
+	// Scan for SKILL.md files and collect all files per skill directory
+	type skillCandidate struct {
+		meta     *SkillMetadata
+		skillDir string // absolute path to the skill directory in the clone
+	}
+	var candidates []skillCandidate
+
+	err = filepath.Walk(tmpDir, func(path string, info os.FileInfo, walkErr error) error {
+		if walkErr != nil {
 			return nil // skip errors
 		}
 		if info.IsDir() {
@@ -136,13 +195,13 @@ func discoverViaClone(cloneURL string, source *SkillSource) ([]SkillMetadata, er
 			return nil
 		}
 
-		content, err := os.ReadFile(path)
-		if err != nil {
+		content, readErr := os.ReadFile(path)
+		if readErr != nil {
 			return nil
 		}
 
-		meta, err := ParseSkillFrontmatter(content)
-		if err != nil {
+		meta, parseErr := ParseSkillFrontmatter(content)
+		if parseErr != nil {
 			return nil
 		}
 
@@ -158,11 +217,51 @@ func discoverViaClone(cloneURL string, source *SkillSource) ([]SkillMetadata, er
 			return nil
 		}
 
-		skills = append(skills, *meta)
+		candidates = append(candidates, skillCandidate{
+			meta:     meta,
+			skillDir: filepath.Dir(path),
+		})
 		return nil
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to scan cloned repository: %w", err)
+	}
+
+	// Walk each skill directory to collect files
+	for i := range candidates {
+		c := &candidates[i]
+		skillDirAbs := c.skillDir
+		var files []string
+		_ = filepath.Walk(skillDirAbs, func(p string, fi os.FileInfo, walkErr error) error {
+			if walkErr != nil {
+				return nil
+			}
+			if fi.IsDir() {
+				return nil
+			}
+
+			// Symlink escape check: resolve symlink and verify it stays under the skill dir
+			if fi.Mode()&os.ModeSymlink != 0 {
+				resolved, resolveErr := filepath.EvalSymlinks(p)
+				if resolveErr != nil {
+					return nil // skip broken symlinks
+				}
+				if !strings.HasPrefix(resolved, skillDirAbs+string(filepath.Separator)) {
+					return nil // skip symlinks that escape the skill directory
+				}
+			}
+
+			rel, _ := filepath.Rel(tmpDir, p)
+			files = append(files, filepath.ToSlash(rel))
+			return nil
+		})
+		sort.Strings(files)
+		c.meta.Files = files
+	}
+
+	var skills []SkillMetadata
+	for _, c := range candidates {
+		skills = append(skills, *c.meta)
 	}
 
 	if len(skills) == 0 && source.SkillFilter != "" {

--- a/pkg/cli/skills/discover.go
+++ b/pkg/cli/skills/discover.go
@@ -195,6 +195,17 @@ func discoverViaClone(cloneURL string, source *SkillSource) ([]SkillMetadata, er
 			return nil
 		}
 
+		// Skip symlinked SKILL.md that resolves outside the clone
+		if info.Mode()&os.ModeSymlink != 0 {
+			resolved, resolveErr := filepath.EvalSymlinks(path)
+			if resolveErr != nil {
+				return nil
+			}
+			if !strings.HasPrefix(resolved, tmpDir+string(filepath.Separator)) {
+				return nil
+			}
+		}
+
 		content, readErr := os.ReadFile(path)
 		if readErr != nil {
 			return nil
@@ -227,7 +238,13 @@ func discoverViaClone(cloneURL string, source *SkillSource) ([]SkillMetadata, er
 		return nil, fmt.Errorf("failed to scan cloned repository: %w", err)
 	}
 
-	// Walk each skill directory to collect files
+	// Build set of all skill dirs for nested-skill isolation
+	allSkillDirs := make(map[string]bool, len(candidates))
+	for _, c := range candidates {
+		allSkillDirs[c.skillDir] = true
+	}
+
+	// Walk each skill directory to collect files, skipping nested skill subtrees
 	for i := range candidates {
 		c := &candidates[i]
 		skillDirAbs := c.skillDir
@@ -237,6 +254,10 @@ func discoverViaClone(cloneURL string, source *SkillSource) ([]SkillMetadata, er
 				return nil
 			}
 			if fi.IsDir() {
+				// Skip nested skill directories (they belong to their own candidate)
+				if p != skillDirAbs && allSkillDirs[p] {
+					return filepath.SkipDir
+				}
 				return nil
 			}
 

--- a/pkg/cli/skills/install.go
+++ b/pkg/cli/skills/install.go
@@ -2,9 +2,12 @@ package skills
 
 import (
 	"fmt"
+	"net/http"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
+	"time"
 )
 
 // ValidateSkillName rejects names that could cause path traversal or
@@ -29,11 +32,147 @@ func ValidateSkillName(name string) error {
 	return nil
 }
 
-// InstallSkill writes SKILL.md content to each agent's skills directory
+// validateRelPath checks that a file-relative path within a skill directory
+// is safe (no traversal, not absolute, clean).
+func validateRelPath(relPath string) error {
+	if relPath == "" {
+		return fmt.Errorf("empty file path")
+	}
+	if filepath.IsAbs(relPath) {
+		return fmt.Errorf("absolute file path %q", relPath)
+	}
+	if strings.Contains(relPath, "..") {
+		return fmt.Errorf("path traversal in %q", relPath)
+	}
+	// Normalize to OS separators for the clean check
+	osPath := filepath.FromSlash(relPath)
+	cleaned := filepath.Clean(osPath)
+	if cleaned != osPath {
+		return fmt.Errorf("file path %q is not clean (resolves to %q)", relPath, cleaned)
+	}
+	return nil
+}
+
+// maxRetryAfter is the maximum time we'll wait for a Retry-After header before giving up.
+const maxRetryAfter = 30 * time.Second
+
+// FetchSkillFiles returns every file under the skill's directory keyed by the
+// skill-directory-relative path (e.g. "SKILL.md", "references/core.md").
+// Uses the cloned tmp dir when available, otherwise raw.githubusercontent.com.
+// All-or-nothing: returns an error (no partial map) on any fetch failure.
+func FetchSkillFiles(client *Client, source *SkillSource, skill *SkillMetadata) (map[string][]byte, error) {
+	if len(skill.Files) == 0 {
+		return nil, fmt.Errorf("skill %q has no files listed from discovery", skill.Name)
+	}
+
+	skillDir := strings.TrimSuffix(skill.RepoPath, "/SKILL.md")
+
+	files := make(map[string][]byte, len(skill.Files))
+	for _, repoPath := range skill.Files {
+		// Derive the skill-relative key
+		relKey := strings.TrimPrefix(repoPath, skillDir+"/")
+		if err := validateRelPath(relKey); err != nil {
+			return nil, fmt.Errorf("unsafe file in skill %q: %w", skill.Name, err)
+		}
+
+		var content []byte
+		var err error
+		if source.cloneDir != "" {
+			// Clone path: read from filesystem
+			absPath := filepath.Join(source.cloneDir, filepath.FromSlash(repoPath))
+			content, err = os.ReadFile(absPath)
+			if err != nil {
+				return nil, fmt.Errorf("failed to read %s from clone: %w", repoPath, err)
+			}
+		} else {
+			// GitHub path: fetch via raw URL with 429-aware retry
+			content, err = fetchWithRetry(client, source, repoPath)
+			if err != nil {
+				return nil, fmt.Errorf("failed to fetch %s: %w", repoPath, err)
+			}
+		}
+
+		files[relKey] = content
+	}
+
+	if _, ok := files["SKILL.md"]; !ok {
+		return nil, fmt.Errorf("skill %q missing SKILL.md in file list", skill.Name)
+	}
+
+	return files, nil
+}
+
+// fetchWithRetry wraps FetchSkillContent with a single retry on 429/403+Retry-After.
+func fetchWithRetry(client *Client, source *SkillSource, repoPath string) ([]byte, error) {
+	content, err := client.FetchSkillContent(source.Owner, source.Repo, source.Ref, repoPath)
+	if err == nil {
+		return content, nil
+	}
+
+	// Check if the error is a rate-limit (429 or 403 with Retry-After).
+	// FetchSkillContent wraps HTTP errors with the status code in the message.
+	// We need a direct HTTP check, so we do a second attempt after waiting.
+	// Since FetchSkillContent already consumed the response, we do a lightweight
+	// probe to decide whether to retry.
+	wait := parseRetryWait(client, source, repoPath)
+	if wait <= 0 {
+		return nil, err // Not a rate-limit error; return original error
+	}
+
+	if wait > maxRetryAfter {
+		return nil, fmt.Errorf("rate-limited; Retry-After %v exceeds %v cap\n→ Try again later. If rate-limited, set GITHUB_TOKEN.", wait, maxRetryAfter)
+	}
+
+	time.Sleep(wait)
+	return client.FetchSkillContent(source.Owner, source.Repo, source.Ref, repoPath)
+}
+
+// parseRetryWait does a HEAD request to check if the URL is rate-limited
+// and returns the Retry-After duration, or 0 if not rate-limited.
+func parseRetryWait(client *Client, source *SkillSource, repoPath string) time.Duration {
+	reqURL := fmt.Sprintf("%s/%s/%s/%s/%s",
+		client.RawGHURL, source.Owner, source.Repo, source.Ref, repoPath)
+
+	req, err := http.NewRequest(http.MethodHead, reqURL, nil)
+	if err != nil {
+		return 0
+	}
+
+	resp, err := client.HTTPClient.Do(req)
+	if err != nil {
+		return 0
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusTooManyRequests && resp.StatusCode != http.StatusForbidden {
+		return 0
+	}
+
+	retryAfter := resp.Header.Get("Retry-After")
+	if retryAfter == "" {
+		// Default fallback for rate-limits without Retry-After
+		return 2 * time.Second
+	}
+
+	seconds, parseErr := strconv.Atoi(retryAfter)
+	if parseErr != nil {
+		return 2 * time.Second // unparseable → use default
+	}
+
+	return time.Duration(seconds) * time.Second
+}
+
+// InstallSkill writes all skill files to each agent's skills directory
 // and updates the lock file.
-func InstallSkill(name string, content []byte, agentPaths []string, lockPath string, source *SkillSource) error {
+func InstallSkill(name string, files map[string][]byte, agentPaths []string, lockPath string, source *SkillSource) error {
 	if err := ValidateSkillName(name); err != nil {
 		return fmt.Errorf("unsafe skill name: %w", err)
+	}
+	if len(files) == 0 {
+		return fmt.Errorf("skill %q has no files", name)
+	}
+	if _, ok := files["SKILL.md"]; !ok {
+		return fmt.Errorf("skill %q missing SKILL.md", name)
 	}
 	if len(agentPaths) == 0 {
 		return fmt.Errorf("no agent paths configured\n→ Run 'sl init' to configure agents")
@@ -45,10 +184,29 @@ func InstallSkill(name string, content []byte, agentPaths []string, lockPath str
 			return fmt.Errorf("failed to create skill directory %s: %w", skillDir, err)
 		}
 
-		skillFile := filepath.Join(skillDir, "SKILL.md")
-		// #nosec G306 -- skill files need to be readable, 0644 is appropriate
-		if err := os.WriteFile(skillFile, content, 0644); err != nil {
-			return fmt.Errorf("failed to write %s: %w", skillFile, err)
+		for relPath, content := range files {
+			// Defense-in-depth: re-validate each relative path
+			if err := validateRelPath(relPath); err != nil {
+				return fmt.Errorf("unsafe file path in skill %q: %w", name, err)
+			}
+
+			destPath := filepath.Join(skillDir, filepath.FromSlash(relPath))
+
+			// Final traversal defense: verify dest is under skillDir
+			rel, relErr := filepath.Rel(skillDir, destPath)
+			if relErr != nil || strings.HasPrefix(rel, "..") {
+				return fmt.Errorf("file path %q escapes skill directory", relPath)
+			}
+
+			// Ensure parent directories exist (e.g. references/)
+			if err := os.MkdirAll(filepath.Dir(destPath), 0755); err != nil {
+				return fmt.Errorf("failed to create directory for %s: %w", destPath, err)
+			}
+
+			// #nosec G306 -- skill files need to be readable, 0644 is appropriate
+			if err := os.WriteFile(destPath, content, 0644); err != nil {
+				return fmt.Errorf("failed to write %s: %w", destPath, err)
+			}
 		}
 	}
 

--- a/pkg/cli/skills/install.go
+++ b/pkg/cli/skills/install.go
@@ -3,6 +3,7 @@ package skills
 import (
 	"fmt"
 	"net/http"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -131,7 +132,7 @@ func fetchWithRetry(client *Client, source *SkillSource, repoPath string) ([]byt
 // and returns the Retry-After duration, or 0 if not rate-limited.
 func parseRetryWait(client *Client, source *SkillSource, repoPath string) time.Duration {
 	reqURL := fmt.Sprintf("%s/%s/%s/%s/%s",
-		client.RawGHURL, source.Owner, source.Repo, source.Ref, repoPath)
+		client.RawGHURL, source.Owner, source.Repo, url.PathEscape(source.Ref), repoPath)
 
 	req, err := http.NewRequest(http.MethodHead, reqURL, nil)
 	if err != nil {

--- a/pkg/cli/skills/install_test.go
+++ b/pkg/cli/skills/install_test.go
@@ -12,9 +12,10 @@ func TestInstallSkill(t *testing.T) {
 	lockPath := filepath.Join(dir, "skills-lock.json")
 
 	content := []byte("---\nname: test-skill\ndescription: Test\n---\nBody")
+	files := map[string][]byte{"SKILL.md": content}
 	source := &SkillSource{Owner: "org", Repo: "repo", Ref: "main", Type: SourceTypeGitHub}
 
-	err := InstallSkill("test-skill", content, []string{agentPath}, lockPath, source)
+	err := InstallSkill("test-skill", files, []string{agentPath}, lockPath, source)
 	if err != nil {
 		t.Fatalf("InstallSkill: %v", err)
 	}
@@ -53,9 +54,10 @@ func TestInstallSkill_MultipleAgentPaths(t *testing.T) {
 	lockPath := filepath.Join(dir, "skills-lock.json")
 
 	content := []byte("---\nname: multi\ndescription: Multi-agent\n---\n")
+	files := map[string][]byte{"SKILL.md": content}
 	source := &SkillSource{Owner: "org", Repo: "repo", Ref: "main", Type: SourceTypeGitHub}
 
-	err := InstallSkill("multi", content, []string{path1, path2}, lockPath, source)
+	err := InstallSkill("multi", files, []string{path1, path2}, lockPath, source)
 	if err != nil {
 		t.Fatalf("InstallSkill: %v", err)
 	}
@@ -76,8 +78,9 @@ func TestUninstallSkill(t *testing.T) {
 
 	// Install first
 	content := []byte("---\nname: removeme\ndescription: Test\n---\n")
+	files := map[string][]byte{"SKILL.md": content}
 	source := &SkillSource{Owner: "org", Repo: "repo", Ref: "main", Type: SourceTypeGitHub}
-	if err := InstallSkill("removeme", content, []string{agentPath}, lockPath, source); err != nil {
+	if err := InstallSkill("removeme", files, []string{agentPath}, lockPath, source); err != nil {
 		t.Fatalf("InstallSkill: %v", err)
 	}
 
@@ -159,7 +162,7 @@ func TestInstallSkill_PathTraversal(t *testing.T) {
 	lockPath := filepath.Join(dir, "skills-lock.json")
 	source := &SkillSource{Owner: "org", Repo: "repo", Ref: "main", Type: SourceTypeGitHub}
 
-	err := InstallSkill("../../../etc/passwd", []byte("evil"), []string{agentPath}, lockPath, source)
+	err := InstallSkill("../../../etc/passwd", map[string][]byte{"SKILL.md": []byte("evil")}, []string{agentPath}, lockPath, source)
 	if err == nil {
 		t.Fatal("expected error for path traversal name")
 	}
@@ -173,7 +176,7 @@ func TestInstallSkill_EmptyAgentPaths(t *testing.T) {
 	lockPath := filepath.Join(dir, "skills-lock.json")
 	source := &SkillSource{Owner: "org", Repo: "repo", Ref: "main", Type: SourceTypeGitHub}
 
-	err := InstallSkill("valid-skill", []byte("content"), []string{}, lockPath, source)
+	err := InstallSkill("valid-skill", map[string][]byte{"SKILL.md": []byte("content")}, []string{}, lockPath, source)
 	if err == nil {
 		t.Fatal("expected error for empty agent paths")
 	}
@@ -188,7 +191,7 @@ func TestInstallSkill_InvalidName(t *testing.T) {
 	agentPath := filepath.Join(dir, ".claude", "skills")
 	source := &SkillSource{Owner: "org", Repo: "repo", Ref: "main", Type: SourceTypeGitHub}
 
-	err := InstallSkill("../evil", []byte("content"), []string{agentPath}, lockPath, source)
+	err := InstallSkill("../evil", map[string][]byte{"SKILL.md": []byte("content")}, []string{agentPath}, lockPath, source)
 	if err == nil {
 		t.Fatal("expected error for invalid name")
 	}
@@ -208,9 +211,10 @@ func TestInstallSkill_RefInLockEntry(t *testing.T) {
 	lockPath := filepath.Join(dir, "skills-lock.json")
 
 	content := []byte("---\nname: ref-skill\ndescription: Test\n---\nBody")
+	files := map[string][]byte{"SKILL.md": content}
 	source := &SkillSource{Owner: "org", Repo: "repo", Ref: "v1.0", Type: SourceTypeGitHub}
 
-	err := InstallSkill("ref-skill", content, []string{agentPath}, lockPath, source)
+	err := InstallSkill("ref-skill", files, []string{agentPath}, lockPath, source)
 	if err != nil {
 		t.Fatalf("InstallSkill: %v", err)
 	}
@@ -282,11 +286,88 @@ func TestInstallSkill_DirCreationFailure(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err := InstallSkill("some-skill", []byte("content"), []string{agentFile}, lockPath, source)
+	err := InstallSkill("some-skill", map[string][]byte{"SKILL.md": []byte("content")}, []string{agentFile}, lockPath, source)
 	if err == nil {
 		t.Fatal("expected error when agent path is a file")
 	}
 	if !contains(err.Error(), "failed to create") {
 		t.Errorf("error = %q, want containing 'failed to create'", err.Error())
+	}
+}
+
+func TestInstallSkill_PathTraversalInFiles(t *testing.T) {
+	dir := t.TempDir()
+	agentPath := filepath.Join(dir, ".claude", "skills")
+	lockPath := filepath.Join(dir, "skills-lock.json")
+	source := &SkillSource{Owner: "org", Repo: "repo", Ref: "main", Type: SourceTypeGitHub}
+
+	files := map[string][]byte{
+		"SKILL.md":   []byte("---\nname: test\ndescription: Test\n---\n"),
+		"../evil.md": []byte("malicious content"),
+	}
+	err := InstallSkill("test-skill", files, []string{agentPath}, lockPath, source)
+	if err == nil {
+		t.Fatal("expected error for path traversal in files map key")
+	}
+	if !contains(err.Error(), "unsafe file path") {
+		t.Errorf("error = %q, want containing 'unsafe file path'", err.Error())
+	}
+}
+
+func TestInstallSkill_MissingSKILLMD(t *testing.T) {
+	dir := t.TempDir()
+	agentPath := filepath.Join(dir, ".claude", "skills")
+	lockPath := filepath.Join(dir, "skills-lock.json")
+	source := &SkillSource{Owner: "org", Repo: "repo", Ref: "main", Type: SourceTypeGitHub}
+
+	files := map[string][]byte{
+		"GENERATION.md": []byte("# Generation"),
+	}
+	err := InstallSkill("test-skill", files, []string{agentPath}, lockPath, source)
+	if err == nil {
+		t.Fatal("expected error for missing SKILL.md")
+	}
+	if !contains(err.Error(), "missing SKILL.md") {
+		t.Errorf("error = %q, want containing 'missing SKILL.md'", err.Error())
+	}
+}
+
+func TestInstallSkill_MultipleFiles(t *testing.T) {
+	dir := t.TempDir()
+	agentPath := filepath.Join(dir, ".claude", "skills")
+	lockPath := filepath.Join(dir, "skills-lock.json")
+	source := &SkillSource{Owner: "org", Repo: "repo", Ref: "main", Type: SourceTypeGitHub}
+
+	files := map[string][]byte{
+		"SKILL.md":               []byte("---\nname: multi-file\ndescription: Test\n---\nBody"),
+		"GENERATION.md":          []byte("# Generation"),
+		"references/core.md":     []byte("# Core"),
+		"references/advanced.md": []byte("# Advanced"),
+	}
+	err := InstallSkill("multi-file", files, []string{agentPath}, lockPath, source)
+	if err != nil {
+		t.Fatalf("InstallSkill: %v", err)
+	}
+
+	// Verify all files were written
+	for relPath, expected := range files {
+		fullPath := filepath.Join(agentPath, "multi-file", filepath.FromSlash(relPath))
+		data, readErr := os.ReadFile(fullPath)
+		if readErr != nil {
+			t.Errorf("file %s not created: %v", relPath, readErr)
+			continue
+		}
+		if string(data) != string(expected) {
+			t.Errorf("file %s: content mismatch: got %q, want %q", relPath, string(data), string(expected))
+		}
+	}
+
+	// Verify lock file has an entry
+	lock, readErr := ReadLocalLock(lockPath)
+	if readErr != nil {
+		t.Fatalf("ReadLocalLock: %v", readErr)
+	}
+	if _, ok := lock.Skills["multi-file"]; !ok {
+		t.Error("skill not in lock file")
 	}
 }

--- a/pkg/cli/skills/record_test.go
+++ b/pkg/cli/skills/record_test.go
@@ -72,7 +72,7 @@ func TestRecordCassettes(t *testing.T) {
 			name:     "github_trees",
 			cassette: "tests/testdata/cassettes/skills/github_trees",
 			call: func(c *Client) error {
-				tree, _, err := c.FetchRepoTree("anthropics", "skills", "main")
+				tree, _, _, err := c.FetchRepoTree("anthropics", "skills", "main")
 				if err != nil {
 					return err
 				}
@@ -104,7 +104,7 @@ func TestRecordCassettes(t *testing.T) {
 			cassette: "tests/testdata/cassettes/skills/github_trees_nonmain_404",
 			call: func(c *Client) error {
 				// different-ai/openwork uses "dev" as default branch; "main" should 404
-				_, _, err := c.FetchRepoTree("different-ai", "openwork", "main")
+				_, _, _, err := c.FetchRepoTree("different-ai", "openwork", "main")
 				if err == nil {
 					return fmt.Errorf("expected 404 for main branch, but got success")
 				}
@@ -117,7 +117,7 @@ func TestRecordCassettes(t *testing.T) {
 			cassette: "tests/testdata/cassettes/skills/github_trees_nonmain",
 			call: func(c *Client) error {
 				// HEAD resolves to the repo's default branch (dev)
-				tree, _, err := c.FetchRepoTree("different-ai", "openwork", "HEAD")
+				tree, _, _, err := c.FetchRepoTree("different-ai", "openwork", "HEAD")
 				if err != nil {
 					return err
 				}

--- a/pkg/cli/skills/source.go
+++ b/pkg/cli/skills/source.go
@@ -2,6 +2,7 @@ package skills
 
 import (
 	"fmt"
+	"os"
 	"strings"
 
 	cligit "github.com/specledger/specledger/pkg/cli/git"
@@ -23,6 +24,17 @@ type SkillSource struct {
 	Ref         string // git ref; empty means auto-resolve (tries HEAD, main, master)
 	Type        SourceType
 	URL         string // original URL for git type
+
+	cloneDir string // temp dir created by discoverViaClone; cleaned up by Cleanup()
+}
+
+// Cleanup removes temporary resources allocated during discovery (e.g. cloned repos).
+// Safe to call multiple times. Should be deferred by the caller of DiscoverSkills.
+func (s *SkillSource) Cleanup() {
+	if s.cloneDir != "" {
+		_ = os.RemoveAll(s.cloneDir)
+		s.cloneDir = ""
+	}
 }
 
 // SourceString returns the canonical "owner/repo" string.

--- a/pkg/cli/skills/vcr_test.go
+++ b/pkg/cli/skills/vcr_test.go
@@ -81,7 +81,7 @@ func TestVCR_Audit(t *testing.T) {
 
 func TestVCR_GitHubTrees(t *testing.T) {
 	c := newVCRClient(t, "github_trees")
-	tree, resolvedRef, err := c.FetchRepoTree("anthropics", "skills", "main")
+	tree, resolvedRef, _, err := c.FetchRepoTree("anthropics", "skills", "main")
 	if err != nil {
 		t.Fatalf("FetchRepoTree: %v", err)
 	}
@@ -126,7 +126,7 @@ func TestVCR_GitHubRaw(t *testing.T) {
 func TestVCR_GitHubTreesNonMainDefault_404(t *testing.T) {
 	// Reproduces #172: Trees API returns 404 when repo uses "dev" not "main"
 	c := newVCRClient(t, "github_trees_nonmain_404")
-	_, _, err := c.FetchRepoTree("different-ai", "openwork", "main")
+	_, _, _, err := c.FetchRepoTree("different-ai", "openwork", "main")
 	if err == nil {
 		t.Fatal("expected error for 404 on main branch")
 	}
@@ -138,7 +138,7 @@ func TestVCR_GitHubTreesNonMainDefault_404(t *testing.T) {
 func TestVCR_GitHubTreesNonMainDefault_HEAD(t *testing.T) {
 	// Verifies HEAD ref resolves to the repo's actual default branch
 	c := newVCRClient(t, "github_trees_nonmain")
-	tree, resolvedRef, err := c.FetchRepoTree("different-ai", "openwork", "HEAD")
+	tree, resolvedRef, _, err := c.FetchRepoTree("different-ai", "openwork", "HEAD")
 	if err != nil {
 		t.Fatalf("FetchRepoTree: %v", err)
 	}
@@ -205,4 +205,61 @@ func TestVCR_GitHubRawNonMain(t *testing.T) {
 		t.Errorf("Name = %q, want %q", meta.Name, "opencode-primitives")
 	}
 	t.Logf("got %d bytes, skill name: %s", len(data), meta.Name)
+}
+
+func TestVCR_FetchSkillFiles_MultiFile(t *testing.T) {
+	c := newVCRClient(t, "github_multi_file")
+	source := &SkillSource{
+		Owner: "test-org",
+		Repo:  "multi-repo",
+		Ref:   "main",
+		Type:  SourceTypeGitHub,
+	}
+
+	// Manually construct the SkillMetadata as discovery would produce it.
+	// This tests FetchSkillFiles in isolation (discovery has its own tests).
+	skill := SkillMetadata{
+		Name:     "multi-skill",
+		RepoPath: "skills/multi-skill/SKILL.md",
+		Files: []string{
+			"skills/multi-skill/GENERATION.md",
+			"skills/multi-skill/SKILL.md",
+			"skills/multi-skill/references/advanced.md",
+			"skills/multi-skill/references/core.md",
+		},
+	}
+
+	files, err := FetchSkillFiles(c, source, &skill)
+	if err != nil {
+		t.Fatalf("FetchSkillFiles: %v", err)
+	}
+
+	// Verify all 4 files returned with correct relative keys
+	wantKeys := []string{"SKILL.md", "GENERATION.md", "references/advanced.md", "references/core.md"}
+	if len(files) != len(wantKeys) {
+		t.Fatalf("got %d files, want %d: %v", len(files), len(wantKeys), mapKeys(files))
+	}
+	for _, key := range wantKeys {
+		if _, ok := files[key]; !ok {
+			t.Errorf("missing key %q in files map", key)
+		}
+		if len(files[key]) == 0 {
+			t.Errorf("file %q is empty", key)
+		}
+	}
+
+	// Verify content fidelity
+	if !contains(string(files["references/core.md"]), "Core concepts") {
+		t.Errorf("references/core.md content wrong: %q", string(files["references/core.md"]))
+	}
+
+	t.Logf("FetchSkillFiles returned %d files", len(files))
+}
+
+func mapKeys(m map[string][]byte) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	return keys
 }

--- a/tests/integration/skills_test.go
+++ b/tests/integration/skills_test.go
@@ -236,6 +236,89 @@ func TestSkillsAddInvalidSource(t *testing.T) {
 	}
 }
 
+func TestSkillsAdd_DownloadsAllFiles(t *testing.T) {
+	env := newSkillsTestEnv(t)
+
+	// Register multi-file skill handlers (overrides default test-org handlers)
+	env.mux.HandleFunc("/repos/multi-org/multi-repo/git/trees/main", func(w http.ResponseWriter, _ *http.Request) {
+		resp := map[string]interface{}{
+			"sha":       "multi123",
+			"truncated": false,
+			"tree": []map[string]interface{}{
+				{"path": "skills/vitest-mock/SKILL.md", "type": "blob", "mode": "100644"},
+				{"path": "skills/vitest-mock/GENERATION.md", "type": "blob", "mode": "100644"},
+				{"path": "skills/vitest-mock/references", "type": "tree", "mode": "040000"},
+				{"path": "skills/vitest-mock/references/core.md", "type": "blob", "mode": "100644"},
+				{"path": "skills/vitest-mock/references/advanced.md", "type": "blob", "mode": "100644"},
+				// Nested skill — should NOT be included in vitest-mock's files
+				{"path": "skills/vitest-mock/nested/SKILL.md", "type": "blob", "mode": "100644"},
+				{"path": "skills/vitest-mock/nested/helper.md", "type": "blob", "mode": "100644"},
+			},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	})
+	env.mux.HandleFunc("/multi-org/multi-repo/main/skills/vitest-mock/SKILL.md", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("---\nname: vitest-mock\ndescription: A multi-file test skill\n---\n# Vitest Mock\nSee references/core.md"))
+	})
+	env.mux.HandleFunc("/multi-org/multi-repo/main/skills/vitest-mock/GENERATION.md", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("# Generation\nGenerated content sentinel"))
+	})
+	env.mux.HandleFunc("/multi-org/multi-repo/main/skills/vitest-mock/references/core.md", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("# Core Reference\ncore-sentinel-content"))
+	})
+	env.mux.HandleFunc("/multi-org/multi-repo/main/skills/vitest-mock/references/advanced.md", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("# Advanced Reference\nadvanced-sentinel-content"))
+	})
+	// Nested SKILL.md (for the nested skill)
+	env.mux.HandleFunc("/multi-org/multi-repo/main/skills/vitest-mock/nested/SKILL.md", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("---\nname: nested-skill\ndescription: A nested skill\n---\n"))
+	})
+
+	output, err := env.run("skill", "add", "multi-org/multi-repo@vitest-mock", "-y")
+	if err != nil {
+		t.Fatalf("sl skill add failed: %v\nOutput: %s", err, output)
+	}
+	if !strings.Contains(output, "Installed vitest-mock") {
+		t.Errorf("output missing install confirmation: %s", output)
+	}
+
+	// Verify all 4 files exist (NOT the nested skill's files)
+	expectedFiles := map[string]string{
+		".claude/skills/vitest-mock/SKILL.md":               "# Vitest Mock",
+		".claude/skills/vitest-mock/GENERATION.md":          "Generated content sentinel",
+		".claude/skills/vitest-mock/references/core.md":     "core-sentinel-content",
+		".claude/skills/vitest-mock/references/advanced.md": "advanced-sentinel-content",
+	}
+	for relPath, sentinel := range expectedFiles {
+		fullPath := filepath.Join(env.projectPath, relPath)
+		data, readErr := os.ReadFile(fullPath)
+		if readErr != nil {
+			t.Errorf("expected file %s missing: %v", relPath, readErr)
+			continue
+		}
+		if !strings.Contains(string(data), sentinel) {
+			t.Errorf("file %s missing sentinel %q, got: %s", relPath, sentinel, string(data))
+		}
+	}
+
+	// Verify nested skill files are NOT in vitest-mock (nested skill isolation)
+	nestedPath := filepath.Join(env.projectPath, ".claude/skills/vitest-mock/nested/helper.md")
+	if _, statErr := os.Stat(nestedPath); statErr == nil {
+		t.Error("nested skill file should NOT be included in vitest-mock install")
+	}
+
+	// Verify lock file has vitest-mock entry
+	lockPath := filepath.Join(env.projectPath, "skills-lock.json")
+	lockData, readErr := os.ReadFile(lockPath)
+	if readErr != nil {
+		t.Fatalf("lock file not found: %v", readErr)
+	}
+	if !strings.Contains(string(lockData), "vitest-mock") {
+		t.Error("lock file missing vitest-mock entry")
+	}
+}
+
 // --- List Tests ---
 
 func TestSkillsList(t *testing.T) {

--- a/tests/testdata/cassettes/skills/github_multi_file.yaml
+++ b/tests/testdata/cassettes/skills/github_multi_file.yaml
@@ -1,0 +1,87 @@
+---
+version: 2
+interactions:
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: raw.githubusercontent.com
+        url: https://raw.githubusercontent.com/test-org/multi-repo/main/skills/multi-skill/GENERATION.md
+        method: GET
+      response:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: -1
+        status: 200 OK
+        code: 200
+        body: "# Generation\nAuto-generated content."
+        headers:
+            Content-Type:
+                - text/plain
+        duration: 50ms
+    - id: 1
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: raw.githubusercontent.com
+        url: https://raw.githubusercontent.com/test-org/multi-repo/main/skills/multi-skill/SKILL.md
+        method: GET
+      response:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: -1
+        status: 200 OK
+        code: 200
+        body: "---\nname: multi-skill\ndescription: A multi-file test skill for VCR replay\n---\n# Multi Skill\nReferences core and advanced docs."
+        headers:
+            Content-Type:
+                - text/plain
+        duration: 50ms
+    - id: 2
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: raw.githubusercontent.com
+        url: https://raw.githubusercontent.com/test-org/multi-repo/main/skills/multi-skill/references/advanced.md
+        method: GET
+      response:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: -1
+        status: 200 OK
+        code: 200
+        body: "# Advanced\nAdvanced usage patterns."
+        headers:
+            Content-Type:
+                - text/plain
+        duration: 50ms
+    - id: 3
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: raw.githubusercontent.com
+        url: https://raw.githubusercontent.com/test-org/multi-repo/main/skills/multi-skill/references/core.md
+        method: GET
+      response:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: -1
+        status: 200 OK
+        code: 200
+        body: "# Core\nCore concepts and API."
+        headers:
+            Content-Type:
+                - text/plain
+        duration: 50ms


### PR DESCRIPTION
## Summary

- `sl skill add` now downloads the entire skill directory (SKILL.md + references/*.md + GENERATION.md + any other files) instead of only the top-level SKILL.md
- Adds truncation detection for the GitHub Trees API with auto-fallback to git clone for very large monorepos
- Includes 429-aware retry with Retry-After header parsing and all-or-nothing install semantics (no partial writes)
- Filters git symlinks (mode 120000) and submodules (mode 160000) from the file list to prevent writing target-string content

Closes #178
Refs #184

## Test plan

- [x] `make lint` — 0 issues
- [x] `make test` — all unit tests pass (skills package + full suite)
- [x] `make test-integration` — all skills integration tests pass (one pre-existing unrelated failure in bootstrap, tracked in #185)
- [x] VCR cassette test (`TestVCR_FetchSkillFiles_MultiFile`) validates multi-file fetch via recorded responses
- [x] Integration test (`TestSkillsAdd_DownloadsAllFiles`) validates end-to-end with nested skill isolation
- [x] Manual e2e: `sl skill add supabase/supabase@vitest -y` installs all 18 expected files

🤖 Generated with [Claude Code](https://claude.com/claude-code)