### PR TITLE
fix(init): drop stale specledger.commit entry from manifest

### DIFF
--- a/.specledger/memory/constitution.md
+++ b/.specledger/memory/constitution.md
@@ -63,7 +63,6 @@ The detailed, up-to-date testing implementation lives in [`tests/README.md`](../
 - E2E tests covering quickstart scenarios are part of the task list, not an afterthought
 - New CLI commands must be classified into one of the 5 command patterns (see [`docs/design/cli.md` — Pattern Classification](../../docs/design/cli.md)) and task lists must include a verification task for pattern compliance
 - Local Supabase stack is validated before pushing (CI enforces this)
-- Use `/specledger.commit` for all git operations (auth-aware session capture)
 
 ## Agent Preferences
 

--- a/README.md
+++ b/README.md
@@ -145,7 +145,6 @@ SpecLedger provides slash commands for Agent Shells such as [Claude Code](https:
 | `/specledger.checklist` | Generate custom checklist for current feature |
 | `/specledger.spike` | Time-boxed exploratory research |
 | `/specledger.checkpoint` | Verify implementation progress and run tests |
-| `/specledger.commit` | Commit and push with auth-aware session capture |
 
 ### Slash Commands: Project Setup
 

--- a/pkg/embedded/templates/manifest.yaml
+++ b/pkg/embedded/templates/manifest.yaml
@@ -60,9 +60,6 @@ playbooks:
       - name: specledger.checkpoint
         path: "commands/specledger.checkpoint.md"
         description: "Verify implementation progress and run tests"
-      - name: specledger.commit
-        path: "commands/specledger.commit.md"
-        description: "Commit and push with auth-aware session capture"
 
     # All skills (stored in skills/)
     skills:


### PR DESCRIPTION
## Summary
- `sl init` printed `Error: commands/specledger.commit.md: failed to read embedded file` on every run because PR #109 deleted the template file but left the entry in `pkg/embedded/templates/manifest.yaml`.
- Remove the stale manifest entry so init runs cleanly.
- Clean up two leftover references to the removed command: the README slash-command table row and the constitution line mandating `/specledger.commit` for git operations.

Note: the original bug report suspected special characters in the directory name. The error is actually unconditional — reproduced in a plain `/tmp` directory. (A separate, pre-existing issue is that directory names with chars like `?` fail project-name validation later in init; out of scope here.)

Closes #183

## Test plan
- [x] `make lint` — 0 issues
- [x] `make test` — all packages pass
- [x] Manually re-ran `sl init --ci` in a fresh repo; the `failed to read embedded file` error no longer appears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)